### PR TITLE
chore: migrate domain to tabrest.ohnice.app

### DIFF
--- a/docs/chrome-web-store-listing.md
+++ b/docs/chrome-web-store-listing.md
@@ -71,7 +71,7 @@ TabRest uses Chrome's native tabs.discard() API. Discarded tabs:
 • All settings stored locally on your device
 • Open source: https://github.com/lamngockhuong/tabrest
 
-🌐 WEBSITE: https://tabrest.khuong.dev
+🌐 WEBSITE: https://tabrest.ohnice.app
 
 Made with ❤️ for tab hoarders everywhere.
 ```
@@ -138,7 +138,7 @@ TabRest sử dụng API tabs.discard() của Chrome. Tab đã giải phóng:
 • Mọi cài đặt lưu cục bộ trên thiết bị
 • Mã nguồn mở: https://github.com/lamngockhuong/tabrest
 
-🌐 WEBSITE: https://tabrest.khuong.dev
+🌐 WEBSITE: https://tabrest.ohnice.app
 
 Làm với ❤️ cho những người "nghiện" mở tab.
 ```
@@ -224,7 +224,7 @@ Làm với ❤️ cho những người "nghiện" mở tab.
 | Field                  | Value                                           |
 | ---------------------- | ----------------------------------------------- |
 | **URL chính thức**     | Không                                           |
-| **URL trang chủ**      | https://tabrest.khuong.dev                      |
+| **URL trang chủ**      | https://tabrest.ohnice.app                      |
 | **URL hỗ trợ**         | https://github.com/lamngockhuong/tabrest/issues |
 | **Nội dung người lớn** | ❌ Không                                         |
 
@@ -235,7 +235,7 @@ Làm với ❤️ cho những người "nghiện" mở tab.
 - [ ] Mô tả tiếng Anh đã copy vào form
 - [ ] Mô tả tiếng Việt đã thêm (nếu cần)
 - [ ] Ít nhất 1 screenshot đã upload
-- [ ] URL trang chủ: https://tabrest.khuong.dev
+- [ ] URL trang chủ: https://tabrest.ohnice.app
 - [ ] URL hỗ trợ: https://github.com/lamngockhuong/tabrest/issues
 - [ ] Ô quảng cáo nhỏ (tùy chọn)
 - [ ] Ô quảng cáo marquee (tùy chọn)

--- a/docs/project-overview-pdr.md
+++ b/docs/project-overview-pdr.md
@@ -106,6 +106,6 @@ host_permissions: http://*/*, https://*/*
 
 ## Links
 
-- **Website:** https://tabrest.khuong.dev
+- **Website:** https://tabrest.ohnice.app
 - **Repository:** GitHub (lamngockhuong/tabrest)
 - **Chrome Web Store:** Coming soon

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "version": "0.0.4",
   "description": "__MSG_extDescription__",
   "default_locale": "en",
-  "homepage_url": "https://tabrest.khuong.dev",
+  "homepage_url": "https://tabrest.ohnice.app",
   "permissions": [
     "tabs",
     "storage",

--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -105,7 +105,7 @@ chrome.runtime.onInstalled.addListener(async (details) => {
     const result = await chrome.storage.local.get("tabrest_lastVersion");
     if (result.tabrest_lastVersion !== currentVersion) {
       await chrome.storage.local.set({ tabrest_lastVersion: currentVersion });
-      chrome.tabs.create({ url: "https://tabrest.khuong.dev/changelog" });
+      chrome.tabs.create({ url: "https://tabrest.ohnice.app/changelog" });
     }
   }
 });

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -11,7 +11,7 @@
     <header>
       <div class="logo-title">
         <img src="../../icons/icon-48.png" alt="TabRest" class="header-logo">
-        <h1><a href="https://tabrest.khuong.dev" target="_blank" rel="noopener noreferrer" class="header-link">TabRest</a></h1>
+        <h1><a href="https://tabrest.ohnice.app" target="_blank" rel="noopener noreferrer" class="header-link">TabRest</a></h1>
       </div>
       <div class="header-actions">
         <button id="theme-toggle" class="icon-btn" title="Toggle theme">
@@ -226,7 +226,7 @@
     </div>
 
     <footer class="popup-footer">
-      <a href="https://tabrest.khuong.dev/changelog" target="_blank" id="app-version" title="What's New">TabRest</a>
+      <a href="https://tabrest.ohnice.app/changelog" target="_blank" id="app-version" title="What's New">TabRest</a>
       <button id="report-bug-btn" class="footer-btn" data-i18n-title="reportBug" title="Report a bug">
         <span data-icon="bug"></span>
       </button>

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -4,7 +4,7 @@ import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
 
 export default defineConfig({
-  site: 'https://tabrest.khuong.dev',
+  site: 'https://tabrest.ohnice.app',
   i18n: {
     defaultLocale: 'en',
     locales: ['en', 'vi'],

--- a/website/public/CNAME
+++ b/website/public/CNAME
@@ -1,1 +1,1 @@
-tabrest.khuong.dev
+tabrest.ohnice.app

--- a/website/public/robots.txt
+++ b/website/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://tabrest.khuong.dev/sitemap-index.xml
+Sitemap: https://tabrest.ohnice.app/sitemap-index.xml


### PR DESCRIPTION
## Summary
- Migrate website domain from `tabrest.khuong.dev` to `tabrest.ohnice.app`
- Update extension `manifest.json` homepage URL, popup links, and changelog redirect
- Update website `astro.config.mjs` site URL, `CNAME`, and `robots.txt` sitemap
- Update docs (`project-overview-pdr.md`, `chrome-web-store-listing.md`)
- Keep `hi@khuong.dev` email and parent `khuong.dev` footer link unchanged

## Test plan
- [ ] Verify popup links open new domain
- [ ] Verify changelog tab opens new domain on version update
- [ ] Configure DNS: `tabrest.ohnice.app` → GitHub Pages
- [ ] Update GitHub Pages custom domain setting in repo
- [ ] Verify sitemap accessible at new domain
- [ ] Update Chrome Web Store listing URL after deploy