### PR TITLE
fix(website): approve esbuild and sharp build scripts

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -17,5 +17,11 @@
     "@tailwindcss/typography": "0.5.19",
     "@tailwindcss/vite": "4.2.2",
     "tailwindcss": "4.2.2"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "sharp"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Deploy Website CI fails with `ERR_PNPM_IGNORED_BUILDS` because pnpm 10+ blocks build scripts by default
- Add `pnpm.onlyBuiltDependencies` to `website/package.json` to whitelist `esbuild` and `sharp`
- Unblocks deployment of the new `tabrest.ohnice.app` domain

## Test plan
- [x] Local: `pnpm install --frozen-lockfile` runs build scripts successfully
- [x] Local: `pnpm build` produces dist/ without errors
- [ ] Deploy Website workflow passes after merge