### PR TITLE
feat: Sprint 2 — gated changelog, optional host perms, suspend warning toast

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -515,5 +515,37 @@
   "ramEstimateTooltip": {
     "message": "Based on ~150 MB per discarded tab. Actual savings vary by page content.",
     "description": "Tooltip explaining the RAM saved estimate"
+  },
+  "formProtectPermDenied": {
+    "message": "Form protection requires website access permission. Toggle skipped.",
+    "description": "Toast when user denies optional host permission for form protection"
+  },
+  "formPermBannerText": {
+    "message": "Form protection was reset due to permission changes.",
+    "description": "Banner shown after upgrade when host permission was implicitly revoked"
+  },
+  "enable": {
+    "message": "Enable",
+    "description": "Generic enable button label"
+  },
+  "formPermGranted": {
+    "message": "Form protection enabled",
+    "description": "Toast after user grants permission via recovery banner"
+  },
+  "showSuspendWarningLabel": {
+    "message": "Show warning before auto-suspend",
+    "description": "Options checkbox label for the on-page warning toast"
+  },
+  "showSuspendWarningHelp": {
+    "message": "Displays a brief on-page toast so you can interact with the tab to keep it alive",
+    "description": "Help text under the suspend warning toggle"
+  },
+  "suspendWarningDelayLabel": {
+    "message": "Warning delay:",
+    "description": "Label for the suspend warning delay select"
+  },
+  "suspendWarningMessage": {
+    "message": "TabRest will suspend this tab to free memory…",
+    "description": "Toast message shown on page before auto-suspend"
   }
 }

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -384,5 +384,29 @@
   },
   "ramEstimateTooltip": {
     "message": "Ước tính dựa trên ~150 MB mỗi tab. Mức tiết kiệm thực tế thay đổi theo nội dung trang."
+  },
+  "formProtectPermDenied": {
+    "message": "Bảo vệ form cần quyền truy cập website. Đã bỏ qua."
+  },
+  "formPermBannerText": {
+    "message": "Bảo vệ form đã bị tắt do thay đổi quyền."
+  },
+  "enable": {
+    "message": "Bật"
+  },
+  "formPermGranted": {
+    "message": "Đã bật bảo vệ form"
+  },
+  "showSuspendWarningLabel": {
+    "message": "Hiển thị cảnh báo trước khi tự động tạm dừng"
+  },
+  "showSuspendWarningHelp": {
+    "message": "Hiện toast ngắn trên trang để bạn có thể tương tác và giữ tab"
+  },
+  "suspendWarningDelayLabel": {
+    "message": "Thời gian cảnh báo:"
+  },
+  "suspendWarningMessage": {
+    "message": "TabRest sắp tạm dừng tab này để giải phóng bộ nhớ…"
   }
 }

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -43,12 +43,13 @@ tabrest/
 | `snooze-manager.js`  | ~120 | Temporary tab/domain protection                  |
 | `session-manager.js` | ~100 | Save/restore tab sessions                        |
 | `stats-collector.js` | ~80  | Usage statistics tracking                        |
+| `form-injector.js`  | ~60  | On-demand form-checker injection + caching       |
 
 ### Content Scripts
 
 | File                 | LOC | Purpose                                     |
 | -------------------- | --- | ------------------------------------------- |
-| `form-checker.js`    | 201 | Detect unsaved forms, report JS heap memory |
+| `form-checker.js`    | 201 | Detect unsaved forms, report JS heap memory (lazy-injected) |
 | `youtube-tracker.js` | 132 | Save/restore YouTube playback position      |
 
 ### UI Components
@@ -68,7 +69,8 @@ tabrest/
 | -------------- | --- | ------------------------------------------- |
 | `constants.js` | 90  | Default settings, alarm names, storage keys |
 | `storage.js`   | 39  | Chrome storage wrapper with caching         |
-| `utils.js`     | 23  | formatBytes, notification helper            |
+| `utils.js`     | 29  | formatBytes, notification helper, semver parsing |
+| `permissions.js` | 32 | Check/request/remove host permissions       |
 | `i18n.js`      | 48  | Internationalization helpers                |
 | `theme.js`     | 88  | Dark/light mode management                  |
 | `icons.js`     | 64  | SVG icon definitions                        |

--- a/docs/project-overview-pdr.md
+++ b/docs/project-overview-pdr.md
@@ -87,7 +87,7 @@ Unloaded tabs remain visible in the tab bar and restore instantly when clicked.
 ```
 tabs, storage, alarms, system.memory, contextMenus,
 tabGroups, scripting, idle, notifications
-host_permissions: http://*/*, https://*/*
+optional_host_permissions: http://*/*, https://*/*
 ```
 
 ### Performance Targets
@@ -100,7 +100,8 @@ host_permissions: http://*/*, https://*/*
 
 | Version | Status  | Key Changes                                         |
 | ------- | ------- | --------------------------------------------------- |
-| 0.0.3   | Current | Tab filter chips, domain snooze fix, UX improvements|
+| 0.0.4   | Current | Changelog auto-open, optional host_permissions, suspend warning |
+| 0.0.3   |         | Tab filter chips, domain snooze fix, UX improvements|
 | 0.0.2   |         | Snooze, scroll restore, offline skip, notifications |
 | 0.0.1   | Initial | Core unload functionality                           |
 

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -1,6 +1,6 @@
 # TabRest - Project Roadmap
 
-## Current Version: 0.0.3
+## Current Version: 0.0.4
 
 ### Completed Features
 
@@ -102,7 +102,13 @@
 
 ## Version History
 
-### v0.0.3 (Current)
+### v0.0.4 (Current)
+- **Phase 06:** Auto-open changelog on minor/major version bumps (silent for patch updates)
+- **Phase 07:** Optional host_permissions + on-demand form-checker injection (breaking for v0.0.3 users)
+- **Phase 08:** Suspend warning toast (3s delay before auto-unload), optional form protection
+- Fixed per-tab JS heap memory monitoring regression
+
+### v0.0.3
 - Added tab filter chips (All/Sleeping/Snoozed/Protected)
 - Fixed cancel snooze for domain-snoozed tabs
 - Improved snooze button UX (show on hover)

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -27,9 +27,10 @@
 │         ▼                                                       │
 │  ┌─────────────────────────────────────────────────────────────┐│
 │  │                   CONTENT SCRIPTS                           ││
+│  │                  (Lazy-injected)                            ││
 │  │  ┌─────────────────────┐  ┌─────────────────────┐           ││
 │  │  │   form-checker.js   │  │ youtube-tracker.js  │           ││
-│  │  │  (all http/https)   │  │ (youtube.com/watch) │           ││
+│  │  │ (on-demand inject)  │  │ (youtube.com/watch) │           ││
 │  │  └─────────────────────┘  └─────────────────────┘           ││
 │  └─────────────────────────────────────────────────────────────┘│
 └─────────────────────────────────────────────────────────────────┘
@@ -61,7 +62,9 @@ service-worker.js
 │   ├── memory-monitor.js
 │   ├── snooze-manager.js
 │   ├── session-manager.js
-│   └── stats-collector.js
+│   ├── stats-collector.js
+│   ├── form-injector.js
+│   └── shared/permissions.js
 └── Internal Functions
     ├── handleMessage()
     ├── getTabsWithStatus()
@@ -76,10 +79,11 @@ service-worker.js
 | ----------------- | ----------------------------------------------- | ------------------------------ |
 | `unload-manager`  | Execute tab discards with protection checks     | stats-collector                |
 | `tab-tracker`     | Track tab activity, trigger timer-based unloads | unload-manager, snooze-manager |
-| `memory-monitor`  | Monitor RAM, trigger memory-based unloads       | tab-tracker, unload-manager    |
+| `memory-monitor`  | Monitor RAM, trigger memory-based unloads       | tab-tracker, unload-manager, form-injector |
 | `snooze-manager`  | Manage temporary protections                    | storage                        |
 | `session-manager` | Save/restore tab sessions                       | storage                        |
 | `stats-collector` | Track unload statistics                         | storage                        |
+| `form-injector`   | Lazy-inject form-checker on demand              | permissions                    |
 
 ## Data Flow
 
@@ -130,6 +134,7 @@ service-worker.js
 2. memory-monitor.checkMemoryAndUnload()
        │
        ├── Check settings.memoryThresholdPercent > 0
+       ├── Proactively ensure form-checker injected (for per-tab heap data)
        ├── chrome.system.memory.getInfo()
        ├── Calculate usage percent
        ├── Apply power mode threshold offset
@@ -311,7 +316,7 @@ service-worker.js
 - `notifications`: Alert on auto-unload
 
 ### Host Permissions
-- `http://*/*`, `https://*/*`: Required for content scripts
+- `http://*/*`, `https://*/*`: Optional (requested on-demand for form detection)
 
 ### Data Security
 - No external network requests

--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,7 @@
     "idle",
     "notifications"
   ],
-  "host_permissions": [
+  "optional_host_permissions": [
     "http://*/*",
     "https://*/*"
   ],
@@ -65,16 +65,6 @@
     "128": "icons/icon-128.png"
   },
   "content_scripts": [
-    {
-      "matches": [
-        "http://*/*",
-        "https://*/*"
-      ],
-      "js": [
-        "src/content/form-checker.js"
-      ],
-      "run_at": "document_idle"
-    },
     {
       "matches": [
         "*://*.youtube.com/watch*"

--- a/src/background/form-injector.js
+++ b/src/background/form-injector.js
@@ -1,0 +1,24 @@
+import { hasHostPermission } from "../shared/permissions.js";
+
+const injectedTabs = new Set();
+
+export async function ensureFormCheckerInjected(tabId, tabUrl) {
+  if (injectedTabs.has(tabId)) return true;
+  if (!tabUrl?.startsWith("http")) return false;
+  if (!(await hasHostPermission())) return false;
+
+  try {
+    await chrome.scripting.executeScript({
+      target: { tabId },
+      files: ["src/content/form-checker.js"],
+    });
+    injectedTabs.add(tabId);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function clearInjectedTab(tabId) {
+  injectedTabs.delete(tabId);
+}

--- a/src/background/memory-monitor.js
+++ b/src/background/memory-monitor.js
@@ -4,8 +4,10 @@ import {
   MEMORY_STALE_THRESHOLD_MS,
   POWER_MODE_CONFIG,
 } from "../shared/constants.js";
+import { hasHostPermission } from "../shared/permissions.js";
 import { getSettings } from "../shared/storage.js";
 import { notifyAutoUnload } from "../shared/utils.js";
+import { ensureFormCheckerInjected } from "./form-injector.js";
 import { getSnoozeData, isTabSnoozed } from "./snooze-manager.js";
 import { getLRUSortedTabs } from "./tab-tracker.js";
 import { discardTab } from "./unload-manager.js";
@@ -103,7 +105,7 @@ export async function checkMemoryAndUnload() {
     // Skip if tab or domain is snoozed (using preloaded data)
     if (await isTabSnoozed(tabId, tab.url, snoozeData)) continue;
 
-    if (await discardTab(tabId, { settings })) {
+    if (await discardTab(tabId, { settings, auto: true })) {
       unloadedCount++;
       // Notify if enabled
       if (settings.notifyOnAutoUnload && tab.title) {
@@ -140,7 +142,10 @@ export function getTabMemory(tabId) {
   return null;
 }
 
-// Check individual tab memory and unload heavy tabs
+// Check individual tab memory and unload heavy tabs.
+// Memory reports come from form-checker.js — when form protection is off but
+// per-tab memory monitoring is on, we still need the script injected so the
+// 30s reporter loop fires. Bootstrap it here on tabs missing memory data.
 export async function checkPerTabMemory() {
   const settings = await getSettings();
   if (settings.perTabJsHeapThresholdMB <= 0) return 0;
@@ -153,8 +158,13 @@ export async function checkPerTabMemory() {
   const tabs = await chrome.tabs.query({});
   let unloadedCount = 0;
 
+  const canInject = await hasHostPermission();
   // Load snooze data once before loop to avoid N+1 storage reads
   const snoozeData = await getSnoozeData();
+
+  // Cap bootstrap injections per tick to avoid thundering-herd executeScript
+  // on session restore with many tabs missing memory data.
+  let bootstrapBudget = MAX_BOOTSTRAP_INJECTS_PER_TICK;
 
   for (const tab of tabs) {
     if (tab.active || tab.discarded) continue;
@@ -163,8 +173,15 @@ export async function checkPerTabMemory() {
     if (await isTabSnoozed(tab.id, tab.url, snoozeData)) continue;
 
     const heapMB = getTabMemory(tab.id);
+    if (heapMB === null && canInject && tab.url?.startsWith("http")) {
+      if (bootstrapBudget > 0) {
+        bootstrapBudget--;
+        ensureFormCheckerInjected(tab.id, tab.url);
+      }
+      continue;
+    }
     if (heapMB && heapMB > settings.perTabJsHeapThresholdMB) {
-      if (await discardTab(tab.id, { settings })) {
+      if (await discardTab(tab.id, { settings, auto: true })) {
         unloadedCount++;
       }
     }
@@ -172,6 +189,8 @@ export async function checkPerTabMemory() {
 
   return unloadedCount;
 }
+
+const MAX_BOOTSTRAP_INJECTS_PER_TICK = 5;
 
 // Re-export formatBytes from shared utils for backwards compatibility
 export { formatBytes } from "../shared/utils.js";

--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -1,7 +1,9 @@
 import { ALARM_NAMES, FORM_CHECK_TIMEOUT_MS } from "../shared/constants.js";
 import { initErrorReporter } from "../shared/error-reporter.js";
+import { hasHostPermission } from "../shared/permissions.js";
 import { getSettings, saveSettings } from "../shared/storage.js";
-import { isValidDomainOrIp, unwrapHostname } from "../shared/utils.js";
+import { isMinorOrMajorBump, isValidDomainOrIp, unwrapHostname } from "../shared/utils.js";
+import { clearInjectedTab, ensureFormCheckerInjected } from "./form-injector.js";
 import {
   checkMemoryAndUnload,
   checkPerTabMemory,
@@ -80,6 +82,9 @@ chrome.runtime.onStartup.addListener(async () => {
   await cleanupStaleActivity();
   await configureToolbarAction();
   await setupSnoozeCleanupAlarm();
+  // Catch the case where the user revoked host permission via chrome://extensions
+  // between sessions; silently flip protectFormTabs off (no banner — not an upgrade).
+  await syncFormPermissionState(false);
   await discardAllTabsOnStartup();
   updateBadge();
 });
@@ -100,17 +105,34 @@ chrome.runtime.onInstalled.addListener(async (details) => {
   const currentVersion = chrome.runtime.getManifest().version;
 
   if (details.reason === "install") {
-    // First install - show onboarding
+    // First install - show onboarding, store version to track future bumps
+    await chrome.storage.local.set({ tabrest_lastVersion: currentVersion });
     chrome.tabs.create({ url: "src/pages/onboarding.html" });
   } else if (details.reason === "update") {
-    // Check if we should show changelog
-    const result = await chrome.storage.local.get("tabrest_lastVersion");
-    if (result.tabrest_lastVersion !== currentVersion) {
-      await chrome.storage.local.set({ tabrest_lastVersion: currentVersion });
+    const stored = await chrome.storage.local.get("tabrest_lastVersion");
+    const prevVersion = details.previousVersion || stored.tabrest_lastVersion;
+
+    if (prevVersion && isMinorOrMajorBump(prevVersion, currentVersion)) {
       chrome.tabs.create({ url: "https://tabrest.ohnice.app/changelog" });
     }
+    await chrome.storage.local.set({ tabrest_lastVersion: currentVersion });
   }
+
+  // Migrate users moving to optional_host_permissions: if form protection was on
+  // but Chrome dropped the implicit grant, force-disable and queue recovery banner.
+  await syncFormPermissionState(details.reason === "update");
 });
+
+async function syncFormPermissionState(showBannerIfChanged) {
+  if (await hasHostPermission()) return;
+  const settings = await getSettings();
+  if (!settings.protectFormTabs) return;
+  settings.protectFormTabs = false;
+  await saveSettings(settings);
+  if (showBannerIfChanged) {
+    await chrome.storage.local.set({ pendingFormPermBanner: true });
+  }
+}
 
 // Add current site to whitelist
 async function addCurrentSiteToWhitelist() {
@@ -295,6 +317,11 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
   if (changeInfo.status === "complete" || changeInfo.url) {
     updateTabActivity(tabId);
   }
+  if (changeInfo.status === "loading" || changeInfo.discarded === true) {
+    // Page navigating or Chrome dropped the tab — injected form-checker is
+    // gone; force re-inject next check.
+    clearInjectedTab(tabId);
+  }
   if (changeInfo.discarded !== undefined) {
     updateBadge();
   }
@@ -304,6 +331,7 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
 chrome.tabs.onRemoved.addListener((tabId) => {
   removeTabActivity(tabId);
   removeTabMemory(tabId);
+  clearInjectedTab(tabId);
   updateBadge();
 });
 
@@ -476,6 +504,8 @@ async function handleMessage(message) {
 // Check if tab has unsaved form data
 async function checkTabFormData(tabId) {
   try {
+    const tab = await chrome.tabs.get(tabId);
+    if (!(await ensureFormCheckerInjected(tabId, tab.url))) return false;
     const response = await Promise.race([
       chrome.tabs.sendMessage(tabId, { action: "checkFormData" }),
       new Promise((resolve) => setTimeout(() => resolve(null), FORM_CHECK_TIMEOUT_MS)),

--- a/src/background/tab-tracker.js
+++ b/src/background/tab-tracker.js
@@ -117,7 +117,7 @@ export async function checkAndUnloadInactiveTabs() {
       `[TabRest] TIMER unload: ${tab.url}, inactive ${inactiveMinutes}min (threshold: ${effectiveDelay}min)`,
     );
 
-    if (await discardTab(tabId, { settings })) {
+    if (await discardTab(tabId, { settings, auto: true })) {
       unloadedCount++;
       // Notify if enabled
       if (settings.notifyOnAutoUnload) {

--- a/src/background/unload-manager.js
+++ b/src/background/unload-manager.js
@@ -1,7 +1,15 @@
 import { FORM_CHECK_TIMEOUT_MS } from "../shared/constants.js";
 import { getSettings } from "../shared/storage.js";
 import { unwrapHostname } from "../shared/utils.js";
+import { ensureFormCheckerInjected } from "./form-injector.js";
 import { recordUnload } from "./stats-collector.js";
+
+// Pinned + whitelist gates only. Returns null if cleared, else { protected, reason }.
+function passesStaticGates(tab, settings) {
+  if (tab.pinned && !settings.unloadPinnedTabs) return { protected: true, reason: "pinned" };
+  if (isWhitelisted(tab.url, settings)) return { protected: true, reason: "whitelist" };
+  return null;
+}
 
 /**
  * Check if tab should be protected from unloading
@@ -18,6 +26,9 @@ async function shouldProtectTab(tab, settings) {
   // Form protection - check for unsaved form data
   if (settings.protectFormTabs) {
     try {
+      if (!(await ensureFormCheckerInjected(tab.id, tab.url))) {
+        return { protected: false };
+      }
       const response = await Promise.race([
         chrome.tabs.sendMessage(tab.id, { action: "checkFormData" }),
         new Promise((resolve) => setTimeout(() => resolve(null), FORM_CHECK_TIMEOUT_MS)),
@@ -26,7 +37,7 @@ async function shouldProtectTab(tab, settings) {
         return { protected: true, reason: "form" };
       }
     } catch {
-      // Content script not loaded, proceed with unload
+      // Content script not loaded or restricted page; proceed with unload.
     }
   }
 
@@ -35,11 +46,12 @@ async function shouldProtectTab(tab, settings) {
 
 // Discard a single tab by ID
 // @param {number} tabId - Tab ID to discard
-// @param {object} options - { settings, force }
+// @param {object} options - { settings, force, auto }
 //   - settings: Pre-fetched settings to avoid refetching in batch
 //   - force: Bypass protection checks (for user-initiated unloads)
+//   - auto: From alarm/memory-monitor — eligible for warning toast + recheck window
 export async function discardTab(tabId, options = {}) {
-  const { settings: providedSettings = null, force = false } = options;
+  const { settings: providedSettings = null, force = false, auto = false } = options;
 
   try {
     const tab = await chrome.tabs.get(tabId);
@@ -51,24 +63,32 @@ export async function discardTab(tabId, options = {}) {
 
     // Skip protection checks if force unload
     if (!force) {
-      if (tab.pinned && !settings.unloadPinnedTabs) return false;
-
-      // Check whitelist
-      const whitelisted = isWhitelisted(tab.url, settings);
-      console.log(
-        `[TabRest] Checking tab ${tabId}: ${tab.url}, whitelist: [${settings.whitelist?.join(", ")}], isWhitelisted: ${whitelisted}`,
-      );
-      if (whitelisted) return false;
-
-      // Check audio/form protection
+      if (passesStaticGates(tab, settings)) return false;
       const protection = await shouldProtectTab(tab, settings);
-      if (protection.protected) {
-        return false;
-      }
+      if (protection.protected) return false;
+    }
+
+    // Auto paths: show warning toast and re-check before committing.
+    let currentTab = tab;
+    if (auto && !force && settings.showSuspendWarning && currentTab.url?.startsWith("http")) {
+      if (currentTab.status === "loading") return false;
+      const message =
+        chrome.i18n.getMessage("suspendWarningMessage") ||
+        "TabRest will suspend this tab to free memory…";
+      await injectSuspendWarning(tabId, settings.suspendWarningDelayMs, message);
+      await new Promise((r) => setTimeout(r, settings.suspendWarningDelayMs));
+
+      const refreshed = await chrome.tabs.get(tabId).catch(() => null);
+      if (!refreshed || refreshed.active || refreshed.discarded) return false;
+      if (refreshed.status === "loading") return false;
+      if (passesStaticGates(refreshed, settings)) return false;
+      const recheck = await shouldProtectTab(refreshed, settings);
+      if (recheck.protected) return false;
+      currentTab = refreshed;
     }
 
     // Save YouTube timestamp before discarding
-    if (settings.saveYouTubeTimestamp && tab.url?.includes("youtube.com/watch")) {
+    if (settings.saveYouTubeTimestamp && currentTab.url?.includes("youtube.com/watch")) {
       try {
         await chrome.tabs.sendMessage(tabId, { action: "saveYouTubeTimestamp" });
       } catch {
@@ -273,6 +293,39 @@ function isWhitelisted(url, settings) {
 // Check if URL is in blacklist (sync - settings passed in)
 function isBlacklisted(url, settings) {
   return matchesDomainList(url, settings?.blacklist);
+}
+
+// Inject self-contained warning toast on the page. Uses Shadow DOM + all:initial
+// to avoid CSS collisions. Silent on restricted URLs / missing permission.
+async function injectSuspendWarning(tabId, delayMs, message) {
+  try {
+    await chrome.scripting.executeScript({
+      target: { tabId },
+      func: (d, m) => {
+        if (window.__tabrestSuspendWarningShown) return;
+        window.__tabrestSuspendWarningShown = true;
+        const host = document.createElement("div");
+        host.id = "__tabrest_warning_toast";
+        host.style.cssText = "position:fixed;top:16px;right:16px;z-index:2147483647;all:initial;";
+        const root = host.attachShadow({ mode: "closed" });
+        const style = document.createElement("style");
+        style.textContent =
+          ".toast{font:14px system-ui,-apple-system,Segoe UI,sans-serif;background:#1f2937;color:#fff;padding:12px 16px;border-radius:8px;box-shadow:0 4px 12px rgba(0,0,0,.3);max-width:320px;line-height:1.4}";
+        const div = document.createElement("div");
+        div.className = "toast";
+        div.textContent = m;
+        root.append(style, div);
+        document.documentElement.appendChild(host);
+        setTimeout(() => {
+          host.remove();
+          delete window.__tabrestSuspendWarningShown;
+        }, d);
+      },
+      args: [delayMs, message],
+    });
+  } catch {
+    // Restricted page or no host permission — skip warning silently.
+  }
 }
 
 async function addTitlePrefix(tabId, prefix) {

--- a/src/content/form-checker.js
+++ b/src/content/form-checker.js
@@ -1,201 +1,205 @@
 // Content script for form data detection and scroll position tracking
-// Injected into web pages to check for unsaved form data and save/restore scroll
+// Injected on-demand via chrome.scripting.executeScript (host permission optional).
 
-// Note: Content scripts can't use ES imports, so constants defined locally
-const SCROLL_POSITIONS_KEY = "tabrest_scroll_positions";
-const SCROLL_MAX_ENTRIES = 100;
+if (!window.__tabrestFormCheckLoaded) {
+  window.__tabrestFormCheckLoaded = true;
 
-chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
-  if (message.action === "checkFormData") {
-    const hasFormData = checkForUnsavedData();
-    sendResponse({ hasFormData });
-  } else if (message.action === "saveScrollPosition") {
-    saveScrollPosition(message.tabId).then((saved) => sendResponse({ saved }));
-    return true; // Async response
-  }
-  return true;
-});
+  // Note: Content scripts can't use ES imports, so constants defined locally
+  const SCROLL_POSITIONS_KEY = "tabrest_scroll_positions";
+  const SCROLL_MAX_ENTRIES = 100;
 
-/**
- * Save current scroll position to storage
- * @param {number} tabId - Tab ID for storage key
- */
-async function saveScrollPosition(tabId) {
-  try {
-    const position = {
-      x: window.scrollX,
-      y: window.scrollY,
-      url: location.href,
-      savedAt: Date.now(),
-    };
-
-    const data = await chrome.storage.local.get(SCROLL_POSITIONS_KEY);
-    const positions = data[SCROLL_POSITIONS_KEY] || {};
-    positions[tabId] = position;
-
-    // Cleanup old entries if over limit
-    const keys = Object.keys(positions);
-    if (keys.length > SCROLL_MAX_ENTRIES) {
-      const sorted = keys.sort((a, b) => positions[a].savedAt - positions[b].savedAt);
-      const toRemove = sorted.slice(0, keys.length - SCROLL_MAX_ENTRIES);
-      for (const k of toRemove) {
-        delete positions[k];
-      }
+  chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+    if (message.action === "checkFormData") {
+      const hasFormData = checkForUnsavedData();
+      sendResponse({ hasFormData });
+    } else if (message.action === "saveScrollPosition") {
+      saveScrollPosition(message.tabId).then((saved) => sendResponse({ saved }));
+      return true; // Async response
     }
-
-    await chrome.storage.local.set({ [SCROLL_POSITIONS_KEY]: positions });
     return true;
-  } catch {
-    return false;
-  }
-}
+  });
 
-/**
- * Restore scroll position if saved for this tab/URL
- */
-async function restoreScrollPosition() {
-  // Check if extension context is valid
-  if (!chrome.runtime?.id) return;
+  /**
+   * Save current scroll position to storage
+   * @param {number} tabId - Tab ID for storage key
+   */
+  async function saveScrollPosition(tabId) {
+    try {
+      const position = {
+        x: window.scrollX,
+        y: window.scrollY,
+        url: location.href,
+        savedAt: Date.now(),
+      };
 
-  try {
-    // Get current tab ID via background
-    const response = await chrome.runtime.sendMessage({ action: "getTabId" });
-    if (!response?.tabId) return;
+      const data = await chrome.storage.local.get(SCROLL_POSITIONS_KEY);
+      const positions = data[SCROLL_POSITIONS_KEY] || {};
+      positions[tabId] = position;
 
-    const data = await chrome.storage.local.get(SCROLL_POSITIONS_KEY);
-    const positions = data[SCROLL_POSITIONS_KEY] || {};
-    const saved = positions[response.tabId];
+      // Cleanup old entries if over limit
+      const keys = Object.keys(positions);
+      if (keys.length > SCROLL_MAX_ENTRIES) {
+        const sorted = keys.sort((a, b) => positions[a].savedAt - positions[b].savedAt);
+        const toRemove = sorted.slice(0, keys.length - SCROLL_MAX_ENTRIES);
+        for (const k of toRemove) {
+          delete positions[k];
+        }
+      }
 
-    if (saved && saved.url === location.href) {
-      // Small delay to ensure page is rendered
-      setTimeout(() => {
-        window.scrollTo(saved.x, saved.y);
-      }, 100);
-
-      // Clean up after restore
-      delete positions[response.tabId];
       await chrome.storage.local.set({ [SCROLL_POSITIONS_KEY]: positions });
-    }
-  } catch {
-    // Ignore errors (extension context invalidated, etc.)
-  }
-}
-
-// Restore scroll on page load
-if (document.readyState === "loading") {
-  document.addEventListener("DOMContentLoaded", restoreScrollPosition);
-} else {
-  restoreScrollPosition();
-}
-
-/**
- * Check if page has unsaved form data (user-modified values)
- * @returns {boolean}
- */
-function checkForUnsavedData() {
-  // Check text inputs and textareas - only if MODIFIED from default
-  const inputs = document.querySelectorAll(
-    'input[type="text"], input[type="email"], input[type="password"], ' +
-      'input[type="search"], input[type="tel"], input[type="url"], ' +
-      "input:not([type]), textarea",
-  );
-
-  for (const input of inputs) {
-    // Skip hidden, readonly, disabled inputs
-    if (input.type === "hidden" || input.readOnly || input.disabled) continue;
-    // Skip if not visible
-    if (input.offsetParent === null) continue;
-
-    // Check if value differs from default (user has typed something)
-    const currentValue = input.value?.trim() || "";
-    const defaultValue = input.defaultValue?.trim() || "";
-    if (currentValue !== defaultValue && currentValue.length > 0) {
       return true;
+    } catch {
+      return false;
     }
   }
 
-  // Check checkboxes/radios that changed from default
-  const checkables = document.querySelectorAll('input[type="checkbox"], input[type="radio"]');
-  for (const input of checkables) {
-    if (input.checked !== input.defaultChecked) {
-      return true;
+  /**
+   * Restore scroll position if saved for this tab/URL
+   */
+  async function restoreScrollPosition() {
+    // Check if extension context is valid
+    if (!chrome.runtime?.id) return;
+
+    try {
+      // Get current tab ID via background
+      const response = await chrome.runtime.sendMessage({ action: "getTabId" });
+      if (!response?.tabId) return;
+
+      const data = await chrome.storage.local.get(SCROLL_POSITIONS_KEY);
+      const positions = data[SCROLL_POSITIONS_KEY] || {};
+      const saved = positions[response.tabId];
+
+      if (saved && saved.url === location.href) {
+        // Small delay to ensure page is rendered
+        setTimeout(() => {
+          window.scrollTo(saved.x, saved.y);
+        }, 100);
+
+        // Clean up after restore
+        delete positions[response.tabId];
+        await chrome.storage.local.set({ [SCROLL_POSITIONS_KEY]: positions });
+      }
+    } catch {
+      // Ignore errors (extension context invalidated, etc.)
     }
   }
 
-  // Check select elements that changed from default
-  const selects = document.querySelectorAll("select");
-  for (const select of selects) {
-    for (const option of select.options) {
-      if (option.selected !== option.defaultSelected) {
+  // Restore scroll on page load
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", restoreScrollPosition);
+  } else {
+    restoreScrollPosition();
+  }
+
+  /**
+   * Check if page has unsaved form data (user-modified values)
+   * @returns {boolean}
+   */
+  function checkForUnsavedData() {
+    // Check text inputs and textareas - only if MODIFIED from default
+    const inputs = document.querySelectorAll(
+      'input[type="text"], input[type="email"], input[type="password"], ' +
+        'input[type="search"], input[type="tel"], input[type="url"], ' +
+        "input:not([type]), textarea",
+    );
+
+    for (const input of inputs) {
+      // Skip hidden, readonly, disabled inputs
+      if (input.type === "hidden" || input.readOnly || input.disabled) continue;
+      // Skip if not visible
+      if (input.offsetParent === null) continue;
+
+      // Check if value differs from default (user has typed something)
+      const currentValue = input.value?.trim() || "";
+      const defaultValue = input.defaultValue?.trim() || "";
+      if (currentValue !== defaultValue && currentValue.length > 0) {
         return true;
       }
     }
+
+    // Check checkboxes/radios that changed from default
+    const checkables = document.querySelectorAll('input[type="checkbox"], input[type="radio"]');
+    for (const input of checkables) {
+      if (input.checked !== input.defaultChecked) {
+        return true;
+      }
+    }
+
+    // Check select elements that changed from default
+    const selects = document.querySelectorAll("select");
+    for (const select of selects) {
+      for (const option of select.options) {
+        if (option.selected !== option.defaultSelected) {
+          return true;
+        }
+      }
+    }
+
+    // Check contenteditable - track via data attribute set on input
+    const editables = document.querySelectorAll('[contenteditable="true"]');
+    for (const el of editables) {
+      if (el.dataset.tabrestModified === "true") {
+        return true;
+      }
+    }
+
+    return false;
   }
 
-  // Check contenteditable - track via data attribute set on input
-  const editables = document.querySelectorAll('[contenteditable="true"]');
-  for (const el of editables) {
-    if (el.dataset.tabrestModified === "true") {
-      return true;
+  // Track contenteditable modifications
+  document.addEventListener(
+    "input",
+    (e) => {
+      if (e.target.isContentEditable) {
+        e.target.dataset.tabrestModified = "true";
+      }
+    },
+    true,
+  );
+
+  // Report JS heap memory usage to background
+  // Guard against duplicate intervals on SPA navigation
+  let memoryReporterId = null;
+
+  function reportMemoryUsage() {
+    // Check if extension context is still valid
+    if (!chrome.runtime?.id) {
+      if (memoryReporterId) {
+        clearInterval(memoryReporterId);
+        memoryReporterId = null;
+      }
+      return;
     }
+
+    // performance.memory is only available in Chrome with the flag or in certain contexts
+    if (!performance.memory) return;
+
+    const heapMB = Math.round(performance.memory.usedJSHeapSize / (1024 * 1024));
+
+    chrome.runtime
+      .sendMessage({
+        action: "reportTabMemory",
+        heapMB,
+      })
+      .catch(() => {
+        // Ignore if background not ready
+      });
   }
 
-  return false;
-}
+  // Start memory reporting with duplicate guard
+  function startMemoryReporting() {
+    if (memoryReporterId) return; // Already running
+    memoryReporterId = setInterval(reportMemoryUsage, 30000);
+    reportMemoryUsage(); // Report once immediately
+  }
 
-// Track contenteditable modifications
-document.addEventListener(
-  "input",
-  (e) => {
-    if (e.target.isContentEditable) {
-      e.target.dataset.tabrestModified = "true";
-    }
-  },
-  true,
-);
-
-// Report JS heap memory usage to background
-// Guard against duplicate intervals on SPA navigation
-let memoryReporterId = null;
-
-function reportMemoryUsage() {
-  // Check if extension context is still valid
-  if (!chrome.runtime?.id) {
+  // Clean up interval on page unload to prevent memory leaks
+  window.addEventListener("beforeunload", () => {
     if (memoryReporterId) {
       clearInterval(memoryReporterId);
       memoryReporterId = null;
     }
-    return;
-  }
+  });
 
-  // performance.memory is only available in Chrome with the flag or in certain contexts
-  if (!performance.memory) return;
-
-  const heapMB = Math.round(performance.memory.usedJSHeapSize / (1024 * 1024));
-
-  chrome.runtime
-    .sendMessage({
-      action: "reportTabMemory",
-      heapMB,
-    })
-    .catch(() => {
-      // Ignore if background not ready
-    });
+  startMemoryReporting();
 }
-
-// Start memory reporting with duplicate guard
-function startMemoryReporting() {
-  if (memoryReporterId) return; // Already running
-  memoryReporterId = setInterval(reportMemoryUsage, 30000);
-  reportMemoryUsage(); // Report once immediately
-}
-
-// Clean up interval on page unload to prevent memory leaks
-window.addEventListener("beforeunload", () => {
-  if (memoryReporterId) {
-    clearInterval(memoryReporterId);
-    memoryReporterId = null;
-  }
-});
-
-startMemoryReporting();

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -183,6 +183,22 @@
       </div>
       <div class="setting">
         <label>
+          <input type="checkbox" id="show-suspend-warning">
+          <span data-i18n="showSuspendWarningLabel">Show warning before auto-suspend</span>
+        </label>
+        <p class="help" data-i18n="showSuspendWarningHelp">Displays a brief on-page toast so you can interact with the tab to keep it alive</p>
+      </div>
+      <div class="setting setting-sub" id="suspend-warning-delay-container">
+        <label for="suspend-warning-delay" data-i18n="suspendWarningDelayLabel">Warning delay:</label>
+        <select id="suspend-warning-delay">
+          <option value="1500">1.5 seconds</option>
+          <option value="3000">3 seconds</option>
+          <option value="5000">5 seconds</option>
+          <option value="8000">8 seconds</option>
+        </select>
+      </div>
+      <div class="setting">
+        <label>
           <input type="checkbox" id="notify-auto-unload">
           <span data-i18n="notifyOnAutoUnload">Notify when tabs are auto-unloaded</span>
         </label>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,6 +1,11 @@
 import { SETTINGS_DEFAULTS } from "../shared/constants.js";
 import { localizeHtml, t } from "../shared/i18n.js";
 import { injectIcons } from "../shared/icons.js";
+import {
+  hasHostPermission,
+  removeHostPermission,
+  requestHostPermission,
+} from "../shared/permissions.js";
 import { getSettings, saveSettings } from "../shared/storage.js";
 import { initTheme, onThemeChange, toggleTheme, updateThemeIcon } from "../shared/theme.js";
 import { formatBytes, getBrowserInfo, isValidDomainOrIp } from "../shared/utils.js";
@@ -26,6 +31,9 @@ const elements = {
   protectForm: document.getElementById("protect-form"),
   showBadge: document.getElementById("show-badge"),
   notifyAutoUnload: document.getElementById("notify-auto-unload"),
+  showSuspendWarning: document.getElementById("show-suspend-warning"),
+  suspendWarningDelay: document.getElementById("suspend-warning-delay"),
+  suspendWarningDelayContainer: document.getElementById("suspend-warning-delay-container"),
   enableStats: document.getElementById("enable-stats"),
   enableTabGroups: document.getElementById("enable-tab-groups"),
   showDiscardedPrefix: document.getElementById("show-discarded-prefix"),
@@ -84,9 +92,13 @@ async function loadSettings() {
   updateIdleThresholdVisibility();
   elements.unloadPinned.checked = currentSettings.unloadPinnedTabs;
   elements.protectAudio.checked = currentSettings.protectAudioTabs;
-  elements.protectForm.checked = currentSettings.protectFormTabs;
+  // protectFormTabs is only truly enabled when host permission is granted.
+  elements.protectForm.checked = currentSettings.protectFormTabs && (await hasHostPermission());
   elements.showBadge.checked = currentSettings.showBadgeCount;
   elements.notifyAutoUnload.checked = currentSettings.notifyOnAutoUnload;
+  elements.showSuspendWarning.checked = currentSettings.showSuspendWarning;
+  elements.suspendWarningDelay.value = String(currentSettings.suspendWarningDelayMs);
+  updateSuspendWarningDelayVisibility();
   elements.enableStats.checked = currentSettings.enableStats;
   elements.enableTabGroups.checked = currentSettings.enableTabGroups;
   elements.showDiscardedPrefix.checked = currentSettings.showDiscardedPrefix;
@@ -104,6 +116,13 @@ function updatePrefixInputVisibility() {
 
 function updateIdleThresholdVisibility() {
   elements.idleThresholdContainer.classList.toggle("hidden", !elements.onlyDiscardIdle.checked);
+}
+
+function updateSuspendWarningDelayVisibility() {
+  elements.suspendWarningDelayContainer.classList.toggle(
+    "hidden",
+    !elements.showSuspendWarning.checked,
+  );
 }
 
 // Render domain list (XSS-safe DOM manipulation)
@@ -170,9 +189,10 @@ function setupEventListeners() {
     { el: elements.idleThreshold, key: "idleThresholdMinutes", type: "number" },
     { el: elements.unloadPinned, key: "unloadPinnedTabs", type: "checkbox" },
     { el: elements.protectAudio, key: "protectAudioTabs", type: "checkbox" },
-    { el: elements.protectForm, key: "protectFormTabs", type: "checkbox" },
     { el: elements.showBadge, key: "showBadgeCount", type: "checkbox" },
     { el: elements.notifyAutoUnload, key: "notifyOnAutoUnload", type: "checkbox" },
+    { el: elements.showSuspendWarning, key: "showSuspendWarning", type: "checkbox" },
+    { el: elements.suspendWarningDelay, key: "suspendWarningDelayMs", type: "number" },
     { el: elements.enableStats, key: "enableStats", type: "checkbox" },
     { el: elements.enableTabGroups, key: "enableTabGroups", type: "checkbox" },
     { el: elements.showDiscardedPrefix, key: "showDiscardedPrefix", type: "checkbox" },
@@ -196,8 +216,29 @@ function setupEventListeners() {
       if (key === "onlyDiscardWhenIdle") {
         updateIdleThresholdVisibility();
       }
+      if (key === "showSuspendWarning") {
+        updateSuspendWarningDelayVisibility();
+      }
     });
   }
+
+  // protectFormTabs has its own handler — it must request optional host permission
+  // before enabling, and revert the toggle if the user denies.
+  elements.protectForm.addEventListener("change", async () => {
+    if (elements.protectForm.checked) {
+      const granted = await requestHostPermission();
+      if (!granted) {
+        elements.protectForm.checked = false;
+        showStatus(t("formProtectPermDenied"));
+        return;
+      }
+    } else {
+      await removeHostPermission();
+    }
+    currentSettings.protectFormTabs = elements.protectForm.checked;
+    await saveSettings(currentSettings);
+    showStatus(t("settingsSaved"));
+  });
 
   // Power mode radios
   for (const radio of elements.powerModeRadios) {

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -1122,6 +1122,38 @@ footer {
 }
 
 /* Review Prompt */
+.form-perm-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--warning);
+  color: #fff;
+  border-radius: 8px;
+  margin-bottom: 12px;
+  animation: slideDown 0.3s ease-out;
+}
+
+.form-perm-banner-text {
+  flex: 1;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.form-perm-banner-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.form-perm-dismiss {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.form-perm-dismiss:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
 .review-prompt {
   display: flex;
   align-items: center;

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -23,6 +23,17 @@
       </div>
     </header>
 
+    <!-- Form Permission Recovery Banner (shown after upgrade if host perm dropped) -->
+    <div class="form-perm-banner" id="form-perm-banner" style="display: none;">
+      <span class="form-perm-banner-text" data-i18n="formPermBannerText">Form protection was reset due to permission changes.</span>
+      <div class="form-perm-banner-actions">
+        <button class="btn btn-sm btn-primary" id="form-perm-grant" data-i18n="enable">Enable</button>
+        <button class="icon-btn form-perm-dismiss" id="form-perm-dismiss" title="Dismiss">
+          <span data-icon="x"></span>
+        </button>
+      </div>
+    </div>
+
     <!-- Review Prompt -->
     <div class="review-prompt" id="review-prompt" style="display: none;">
       <span class="review-prompt-text" data-i18n="enjoyingTabRest">Enjoying TabRest?</span>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -6,6 +6,7 @@ import {
   formatDiagnosticsJSON,
   formatDiagnosticsText,
 } from "../shared/log-collector.js";
+import { requestHostPermission } from "../shared/permissions.js";
 import { getSettings, saveSettings } from "../shared/storage.js";
 import { initTheme, onThemeChange, toggleTheme, updateThemeIcon } from "../shared/theme.js";
 import { formatBytes, getBrowserInfo } from "../shared/utils.js";
@@ -63,6 +64,10 @@ const elements = {
   reviewYes: document.getElementById("review-yes"),
   reviewNo: document.getElementById("review-no"),
   reviewDismiss: document.getElementById("review-dismiss"),
+  // Form permission recovery banner
+  formPermBanner: document.getElementById("form-perm-banner"),
+  formPermGrant: document.getElementById("form-perm-grant"),
+  formPermDismiss: document.getElementById("form-perm-dismiss"),
   // Bug report
   reportBugBtn: document.getElementById("report-bug-btn"),
   bugReportModal: document.getElementById("bug-report-modal"),
@@ -509,6 +514,29 @@ function hideReviewPrompt() {
   elements.reviewPrompt.style.display = "none";
 }
 
+async function checkFormPermBanner() {
+  const { pendingFormPermBanner } = await chrome.storage.local.get("pendingFormPermBanner");
+  if (!pendingFormPermBanner) return;
+  elements.formPermBanner.style.display = "flex";
+  injectIcons();
+}
+
+async function dismissFormPermBanner() {
+  elements.formPermBanner.style.display = "none";
+  await chrome.storage.local.remove("pendingFormPermBanner");
+}
+
+async function handleFormPermGrant() {
+  const granted = await requestHostPermission();
+  if (granted) {
+    const settings = await getSettings();
+    settings.protectFormTabs = true;
+    await saveSettings(settings);
+    showToast(t("formPermGranted"));
+  }
+  await dismissFormPermBanner();
+}
+
 function incrementDismiss() {
   chrome.storage.local.get("reviewPromptDismissCount", (data) => {
     chrome.storage.local.set({
@@ -798,6 +826,10 @@ function setupEventListeners() {
     hideReviewPrompt();
   });
 
+  // Form permission recovery banner handlers
+  elements.formPermGrant?.addEventListener("click", handleFormPermGrant);
+  elements.formPermDismiss?.addEventListener("click", dismissFormPermBanner);
+
   // Bug report modal handlers
   let cachedDiagnostics = null;
 
@@ -862,6 +894,7 @@ async function init() {
     renderSessions(),
     renderDetailedStats(),
     checkReviewPrompt(),
+    checkFormPermBanner(),
   ]);
   setupEventListeners();
 }

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -34,6 +34,10 @@ export const SETTINGS_DEFAULTS = {
   notifyOnAutoUnload: false,
   // Error reporting (opt-out) - send anonymous crash reports
   enableErrorReporting: true,
+  // Show on-page warning toast before auto-discard (timer/memory paths only)
+  showSuspendWarning: true,
+  // Delay between toast appearance and discard, in ms
+  suspendWarningDelayMs: 3000,
 };
 
 // YouTube timestamp storage key

--- a/src/shared/permissions.js
+++ b/src/shared/permissions.js
@@ -1,0 +1,39 @@
+// Helpers for the optional host permission ("http://*/*", "https://*/*").
+// Used by form protection. YouTube tracker keeps its narrow static match.
+
+const HOST_ORIGINS = ["http://*/*", "https://*/*"];
+
+// Cache the permission state per session: `chrome.permissions.contains` is an
+// async IPC fired once per discard candidate / popup form check / per-tab heap
+// bootstrap. The runtime listeners below invalidate the cache when the user
+// grants or revokes the permission.
+let cachedHasPermission = null;
+
+if (chrome?.permissions?.onAdded) {
+  chrome.permissions.onAdded.addListener(() => {
+    cachedHasPermission = null;
+  });
+}
+if (chrome?.permissions?.onRemoved) {
+  chrome.permissions.onRemoved.addListener(() => {
+    cachedHasPermission = null;
+  });
+}
+
+export async function hasHostPermission() {
+  if (cachedHasPermission !== null) return cachedHasPermission;
+  cachedHasPermission = await chrome.permissions.contains({ origins: HOST_ORIGINS });
+  return cachedHasPermission;
+}
+
+export async function requestHostPermission() {
+  const granted = await chrome.permissions.request({ origins: HOST_ORIGINS });
+  cachedHasPermission = granted;
+  return granted;
+}
+
+export async function removeHostPermission() {
+  const removed = await chrome.permissions.remove({ origins: HOST_ORIGINS });
+  if (removed) cachedHasPermission = false;
+  return removed;
+}

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -87,6 +87,23 @@ export function isValidDomainOrIp(input) {
   return false;
 }
 
+export function parseSemver(version) {
+  if (!version || typeof version !== "string") return null;
+  const m = version.match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!m) return null;
+  return { major: +m[1], minor: +m[2], patch: +m[3] };
+}
+
+// True if curr bumps major or minor compared to prev. Patch-only or downgrade returns false.
+export function isMinorOrMajorBump(prev, curr) {
+  const a = parseSemver(prev);
+  const b = parseSemver(curr);
+  if (!a || !b) return false;
+  if (b.major > a.major) return true;
+  if (b.major === a.major && b.minor > a.minor) return true;
+  return false;
+}
+
 // Format bytes to human readable string
 export function formatBytes(bytes) {
   if (!bytes || bytes === 0) return "0 B";

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -53,6 +53,14 @@ global.chrome = {
       getInfo: vi.fn(() => Promise.resolve({ capacity: 8589934592 })),
     },
   },
+  permissions: {
+    contains: vi.fn(() => Promise.resolve(true)),
+    request: vi.fn(() => Promise.resolve(true)),
+    remove: vi.fn(() => Promise.resolve(true)),
+  },
+  scripting: {
+    executeScript: vi.fn(() => Promise.resolve([])),
+  },
 };
 
 // Reset all mocks before each test

--- a/tests/shared/utils.test.js
+++ b/tests/shared/utils.test.js
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { formatBytes, isValidDomainOrIp } from "../../src/shared/utils.js";
+import {
+  formatBytes,
+  isMinorOrMajorBump,
+  isValidDomainOrIp,
+  parseSemver,
+} from "../../src/shared/utils.js";
 
 describe("formatBytes", () => {
   it("returns '0 B' for zero bytes", () => {
@@ -71,5 +76,57 @@ describe("isValidDomainOrIp", () => {
     expect(isValidDomainOrIp("1:2:::3")).toBe(false);
     expect(isValidDomainOrIp("abcd:::")).toBe(false);
     expect(isValidDomainOrIp("1::2::3")).toBe(false);
+  });
+});
+
+describe("parseSemver", () => {
+  it("parses standard semver", () => {
+    expect(parseSemver("1.2.3")).toEqual({ major: 1, minor: 2, patch: 3 });
+    expect(parseSemver("0.0.4")).toEqual({ major: 0, minor: 0, patch: 4 });
+  });
+
+  it("ignores pre-release suffix", () => {
+    expect(parseSemver("1.2.3-beta.1")).toEqual({ major: 1, minor: 2, patch: 3 });
+  });
+
+  it("returns null for invalid input", () => {
+    expect(parseSemver("")).toBe(null);
+    expect(parseSemver(null)).toBe(null);
+    expect(parseSemver(undefined)).toBe(null);
+    expect(parseSemver("1.2")).toBe(null);
+    expect(parseSemver("abc")).toBe(null);
+    expect(parseSemver(123)).toBe(null);
+  });
+});
+
+describe("isMinorOrMajorBump", () => {
+  it("returns false for patch bumps", () => {
+    expect(isMinorOrMajorBump("0.0.4", "0.0.5")).toBe(false);
+    expect(isMinorOrMajorBump("1.2.3", "1.2.99")).toBe(false);
+  });
+
+  it("returns true for minor bumps", () => {
+    expect(isMinorOrMajorBump("0.0.4", "0.1.0")).toBe(true);
+    expect(isMinorOrMajorBump("1.2.3", "1.3.0")).toBe(true);
+  });
+
+  it("returns true for major bumps", () => {
+    expect(isMinorOrMajorBump("0.9.9", "1.0.0")).toBe(true);
+    expect(isMinorOrMajorBump("1.5.5", "2.0.0")).toBe(true);
+  });
+
+  it("returns false for downgrades", () => {
+    expect(isMinorOrMajorBump("1.2.0", "1.1.0")).toBe(false);
+    expect(isMinorOrMajorBump("2.0.0", "1.9.9")).toBe(false);
+  });
+
+  it("returns false for invalid versions", () => {
+    expect(isMinorOrMajorBump(null, "1.0.0")).toBe(false);
+    expect(isMinorOrMajorBump("1.0.0", null)).toBe(false);
+    expect(isMinorOrMajorBump("abc", "1.0.0")).toBe(false);
+  });
+
+  it("handles same version", () => {
+    expect(isMinorOrMajorBump("1.0.0", "1.0.0")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Drowzy feature parity, Sprint 2 (3 phases, ~13h effort).

- **Phase 06 — Gated changelog auto-open**: only minor/major bumps open the changelog tab on update; patches stay invisible. New `parseSemver` / `isMinorOrMajorBump` helpers in `src/shared/utils.js` with 19 unit tests.
- **Phase 07 — Optional host_permissions** (CWS install-warning blocker): `host_permissions` → `optional_host_permissions`, form-checker dropped from static `content_scripts`, lazy-injected via new `src/background/form-injector.js`. Permission requested on demand when user toggles **Protect form tabs**. v0.0.4 → next upgrade migration: silently force-disables `protectFormTabs` and surfaces a one-click "Enable" recovery banner in the popup. New `src/shared/permissions.js` wraps `chrome.permissions.*` with cached lookups + `onAdded`/`onRemoved` invalidation.
- **Phase 08 — Suspend warning toast**: 3-second on-page Shadow-DOM toast before auto-discard. After delay, re-checks active / loading / pinned / whitelist / form / audio. Configurable delay (1.5–8s) and toggle in options. Manual discards (popup / keyboard / context menu / startup-all) bypass.

**Bonus fix** — per-tab JS heap monitor would have regressed silently with Phase 07 (memory reporter rides inside the now-on-demand `form-checker.js`). `checkPerTabMemory` now bootstraps injection on tabs missing memory data, throttled to 5 per tick.

i18n parity maintained (8 new keys in en + vi).

## Test plan

- [x] `pnpm test` — 113 / 113 pass
- [x] `npx biome check src/` — clean
- [ ] Load unpacked → no "Read your data on all websites" install warning
- [ ] Toggle **Protect form tabs** ON in options → permission prompt appears; deny → toggle reverts + toast
- [ ] Type in form on inactive tab → warning shows → typing keeps it alive
- [ ] Idle tab past timer threshold → toast appears for 3s then tab discarded
- [ ] Click toolbar **Unload current** during the 3s window → no toast on the active tab (manual path)
- [ ] Patch bump simulation (`0.0.4 → 0.0.5`) → no changelog tab opens
- [ ] Minor bump simulation (`0.0.4 → 0.1.0`) → changelog tab opens
- [ ] Switch Chrome locale to `vi` → all new strings translated
- [ ] Verify `optional_host_permissions` install warning behaviour on a CWS draft submission before promoting to public

## Follow-ups

- M1 — re-check snooze in the 3s warning window
- L6 — wire real interaction detection (currently relies on form-edit + tab activation)
- Rename `ensureFormCheckerInjected` if dual-use grows