### PR TITLE
feat: Sprint 3 — side panel + whitelist/sessions import-export

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -337,6 +337,14 @@
     "message": "Discard other tabs",
     "description": "Toolbar action option"
   },
+  "useSidePanel": {
+    "message": "Open in side panel instead of popup",
+    "description": "Side panel toggle label"
+  },
+  "useSidePanelHelp": {
+    "message": "Side panel stays open across tab switches. Requires Chrome 114+.",
+    "description": "Side panel toggle help text"
+  },
   "saveYouTubeTimestamp": {
     "message": "Save YouTube playback position",
     "description": "YouTube timestamp setting"
@@ -547,5 +555,57 @@
   "suspendWarningMessage": {
     "message": "TabRest will suspend this tab to free memory…",
     "description": "Toast message shown on page before auto-suspend"
+  },
+  "exportList": {
+    "message": "Export",
+    "description": "Button label to export a domain list to clipboard"
+  },
+  "importList": {
+    "message": "Import",
+    "description": "Button label to import a domain list from clipboard"
+  },
+  "exportSessions": {
+    "message": "Export Sessions",
+    "description": "Button label to export sessions to clipboard"
+  },
+  "importSessions": {
+    "message": "Import Sessions",
+    "description": "Button label to import sessions from clipboard"
+  },
+  "exportedToClipboard": {
+    "message": "Copied to clipboard",
+    "description": "Toast confirming export completed"
+  },
+  "exportFailed": {
+    "message": "Export failed",
+    "description": "Toast when clipboard write fails"
+  },
+  "pasteImportJson": {
+    "message": "Paste exported JSON below:",
+    "description": "Prompt label for import textarea"
+  },
+  "importedNAdded": {
+    "message": "Added $1, skipped $2",
+    "description": "Toast after import completes",
+    "placeholders": {
+      "1": { "content": "$1" },
+      "2": { "content": "$2" }
+    }
+  },
+  "importFailed_invalidJson": {
+    "message": "Import failed: invalid JSON",
+    "description": "Toast when imported text is not valid JSON"
+  },
+  "importFailed_invalidShape": {
+    "message": "Import failed: invalid format",
+    "description": "Toast when imported JSON has wrong structure"
+  },
+  "importFailed_unsupportedVersion": {
+    "message": "Import failed: unsupported version",
+    "description": "Toast when imported JSON uses an unsupported schema version"
+  },
+  "importFailed_wrongType": {
+    "message": "Import failed: wrong type for this list",
+    "description": "Toast when imported type does not match (e.g. blacklist into whitelist)"
   }
 }

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -250,6 +250,12 @@
   "actionDiscardOthers": {
     "message": "Dỡ các tab khác"
   },
+  "useSidePanel": {
+    "message": "Mở trong side panel thay vì popup"
+  },
+  "useSidePanelHelp": {
+    "message": "Side panel giữ mở khi chuyển tab. Yêu cầu Chrome 114+."
+  },
   "saveYouTubeTimestamp": {
     "message": "Lưu vị trí phát YouTube"
   },
@@ -408,5 +414,45 @@
   },
   "suspendWarningMessage": {
     "message": "TabRest sắp tạm dừng tab này để giải phóng bộ nhớ…"
+  },
+  "exportList": {
+    "message": "Xuất"
+  },
+  "importList": {
+    "message": "Nhập"
+  },
+  "exportSessions": {
+    "message": "Xuất phiên"
+  },
+  "importSessions": {
+    "message": "Nhập phiên"
+  },
+  "exportedToClipboard": {
+    "message": "Đã sao chép vào clipboard"
+  },
+  "exportFailed": {
+    "message": "Xuất thất bại"
+  },
+  "pasteImportJson": {
+    "message": "Dán JSON đã xuất vào đây:"
+  },
+  "importedNAdded": {
+    "message": "Đã thêm $1, bỏ qua $2",
+    "placeholders": {
+      "1": { "content": "$1" },
+      "2": { "content": "$2" }
+    }
+  },
+  "importFailed_invalidJson": {
+    "message": "Nhập thất bại: JSON không hợp lệ"
+  },
+  "importFailed_invalidShape": {
+    "message": "Nhập thất bại: định dạng không hợp lệ"
+  },
+  "importFailed_unsupportedVersion": {
+    "message": "Nhập thất bại: phiên bản không được hỗ trợ"
+  },
+  "importFailed_wrongType": {
+    "message": "Nhập thất bại: sai loại danh sách"
   }
 }

--- a/docs/chrome-web-store-listing.md
+++ b/docs/chrome-web-store-listing.md
@@ -56,6 +56,8 @@ TabRest automatically unloads inactive browser tabs to free up memory and keep y
 • YouTube position restore - resume where you left off
 • Scroll position restore when tabs reload
 • Auto-unload notifications
+• Side panel mode - open in sidebar instead of popup
+• Import/export settings - backup and restore your configuration
 • Multi-language support (English & Vietnamese)
 
 💡 HOW IT WORKS:
@@ -123,6 +125,8 @@ TabRest tự động giải phóng bộ nhớ các tab không hoạt động, gi
 • Khôi phục vị trí YouTube - tiếp tục xem từ chỗ dừng
 • Khôi phục vị trí cuộn khi tab tải lại
 • Thông báo khi giải phóng tab
+• Giao diện side panel (thay thế cho popup)
+• Xuất/nhập cấu hình (clipboard-based)
 • Đa ngôn ngữ (Tiếng Anh & Tiếng Việt)
 
 💡 CÁCH HOẠT ĐỘNG:

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -41,7 +41,7 @@ tabrest/
 | `tab-tracker.js`     | 173  | LRU activity tracking, inactivity timer checks   |
 | `memory-monitor.js`  | 157  | System RAM monitoring, per-tab JS heap tracking  |
 | `snooze-manager.js`  | ~120 | Temporary tab/domain protection                  |
-| `session-manager.js` | ~100 | Save/restore tab sessions                        |
+| `session-manager.js` | ~130 | Save/restore tab sessions, import with merge & dedup |
 | `stats-collector.js` | ~80  | Usage statistics tracking                        |
 | `form-injector.js`  | ~60  | On-demand form-checker injection + caching       |
 
@@ -67,13 +67,14 @@ tabrest/
 
 | File           | LOC | Purpose                                     |
 | -------------- | --- | ------------------------------------------- |
-| `constants.js` | 90  | Default settings, alarm names, storage keys |
+| `constants.js` | 99  | Default settings, alarm names, storage keys |
 | `storage.js`   | 39  | Chrome storage wrapper with caching         |
-| `utils.js`     | 29  | formatBytes, notification helper, semver parsing |
+| `utils.js`     | 51  | formatBytes, notification helper, semver parsing |
 | `permissions.js` | 32 | Check/request/remove host permissions       |
 | `i18n.js`      | 48  | Internationalization helpers                |
 | `theme.js`     | 88  | Dark/light mode management                  |
 | `icons.js`     | 64  | SVG icon definitions                        |
+| `import-export.js` | 45 | Session/config export/import with schema validation |
 
 ### Pages
 
@@ -95,8 +96,10 @@ service-worker.js (orchestrator)
 │   ├── tab-tracker.js (getLRUSortedTabs)
 │   └── unload-manager.js
 ├── session-manager.js
+│   └── import-export.js (schema validation)
 ├── snooze-manager.js
 └── shared/*
+    └── import-export.js
 ```
 
 ## Key Data Structures

--- a/docs/project-overview-pdr.md
+++ b/docs/project-overview-pdr.md
@@ -71,6 +71,8 @@ Unloaded tabs remain visible in the tab bar and restore instantly when clicked.
 | Notifications    | Alert when tabs auto-unloaded                     |
 | Statistics       | Track tabs unloaded, memory saved                 |
 | Sessions         | Save/restore tab collections                      |
+| Side panel       | Open UI in side panel instead of popup (Manifest V3) |
+| Import/export    | Backup/restore sessions & whitelists via clipboard |
 
 ### Internationalization
 - English (default)
@@ -100,7 +102,7 @@ optional_host_permissions: http://*/*, https://*/*
 
 | Version | Status  | Key Changes                                         |
 | ------- | ------- | --------------------------------------------------- |
-| 0.0.4   | Current | Changelog auto-open, optional host_permissions, suspend warning |
+| 0.0.4   | Current | Changelog auto-open, optional host_permissions, suspend warning, side panel, import/export |
 | 0.0.3   |         | Tab filter chips, domain snooze fix, UX improvements|
 | 0.0.2   |         | Snooze, scroll restore, offline skip, notifications |
 | 0.0.1   | Initial | Core unload functionality                           |

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -106,6 +106,8 @@
 - **Phase 06:** Auto-open changelog on minor/major version bumps (silent for patch updates)
 - **Phase 07:** Optional host_permissions + on-demand form-checker injection (breaking for v0.0.3 users)
 - **Phase 08:** Suspend warning toast (3s delay before auto-unload), optional form protection
+- **Phase 09:** Side panel mode (alternative to popup, reuses popup UI, new `chrome.windows.onFocusChanged` listener)
+- **Phase 10:** Import/export sessions (clipboard-based) + whitelist/blacklist export/import in options
 - Fixed per-tab JS heap memory monitoring regression
 
 ### v0.0.3

--- a/docs/store-description.md
+++ b/docs/store-description.md
@@ -19,6 +19,8 @@ Features:
 - Tab groups support
 - Whitelist your favorite sites
 - Track memory saved statistics
+- Side panel mode - open UI in sidebar instead of popup
+- Import/export settings - backup and restore your configuration
 
 Keyboard Shortcuts:
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -6,10 +6,15 @@
 ┌─────────────────────────────────────────────────────────────────┐
 │                        CHROME BROWSER                           │
 ├─────────────────────────────────────────────────────────────────┤
-│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐              │
-│  │   Popup     │  │   Options   │  │   Pages     │              │
-│  │  (popup.*)  │  │ (options.*) │  │ (pages/*)   │              │
-│  └──────┬──────┘  └──────┬──────┘  └─────────────┘              │
+│  ┌─────────────┐  ┌─────────────┐  ┌──────────────┐             │
+│  │   Popup     │  │   Options   │  │    Pages     │             │
+│  │  (popup.*)  │  │ (options.*) │  │  (pages/*)   │             │
+│  └──────┬──────┘  └──────┬──────┘  └──────────────┘             │
+│         │                │                                      │
+│  ┌──────┴────────────────┴──────────────────────────────┐       │
+│  │  Side Panel (optional, useSidePanel setting)        │       │
+│  │  Reuses popup.html/js/css when active               │       │
+│  └──────────────────────────────────────────────────────┘       │
 │         │                │                                      │
 │         │    chrome.runtime.sendMessage                         │
 │         ▼                ▼                                      │
@@ -19,8 +24,9 @@
 │  │  ┌─────────────┬─────────────┬─────────────┬──────────────┐ ││
 │  │  │ unload-mgr  │ tab-tracker │ memory-mon  │ snooze-mgr   │ ││
 │  │  │             │             │             │              │ ││
-│  │  │ session-mgr │ stats-coll  │             │              │ ││
+│  │  │ session-mgr │ stats-coll  │ window mgr* │ form-inject  │ ││
 │  │  └─────────────┴─────────────┴─────────────┴──────────────┘ ││
+│  │  * chrome.windows.onFocusChanged listener                    ││
 │  └──────┬──────────────────────────────────────────────────────┘│
 │         │                                                       │
 │         │    chrome.tabs.sendMessage                            │
@@ -239,18 +245,19 @@ service-worker.js
 
 ### Chrome Events → Actions
 
-| Event                    | Handler                                          | Action          |
-| ------------------------ | ------------------------------------------------ | --------------- |
-| `runtime.onStartup`      | Initialize all trackers, sync tabs, setup alarms | Startup         |
-| `runtime.onInstalled`    | Same as startup + show onboarding/changelog      | Install/Update  |
-| `tabs.onActivated`       | Update tab activity timestamp                    | Tab focus       |
-| `tabs.onUpdated`         | Update activity, refresh badge                   | Tab navigation  |
-| `tabs.onRemoved`         | Cleanup activity & memory entries                | Tab close       |
-| `alarms.onAlarm`         | Route to appropriate check function              | Timer tick      |
-| `commands.onCommand`     | Execute keyboard shortcut action                 | Hotkey          |
-| `contextMenus.onClicked` | Execute context menu action                      | Right-click     |
-| `storage.onChanged`      | Reconfigure alarms, toolbar, badge               | Settings change |
-| `runtime.onMessage`      | Route to command handler                         | Message         |
+| Event                    | Handler                                          | Action                    |
+| ------------------------ | ------------------------------------------------ | ------------------------- |
+| `runtime.onStartup`      | Initialize all trackers, sync tabs, setup alarms | Startup                   |
+| `runtime.onInstalled`    | Same as startup + show onboarding/changelog      | Install/Update            |
+| `tabs.onActivated`       | Update tab activity timestamp                    | Tab focus                 |
+| `tabs.onUpdated`         | Update activity, refresh badge                   | Tab navigation            |
+| `tabs.onRemoved`         | Cleanup activity & memory entries                | Tab close                 |
+| `windows.onFocusChanged` | Update badge across windows (side panel mode)    | Window focus change       |
+| `alarms.onAlarm`         | Route to appropriate check function              | Timer tick                |
+| `commands.onCommand`     | Execute keyboard shortcut action                 | Hotkey                    |
+| `contextMenus.onClicked` | Execute context menu action                      | Right-click               |
+| `storage.onChanged`      | Reconfigure alarms, toolbar, badge               | Settings change           |
+| `runtime.onMessage`      | Route to command handler                         | Message (include import)  |
 
 ### Alarm Schedule
 
@@ -279,6 +286,7 @@ service-worker.js
 { command: "get-sessions" }
 { command: "save-session", name: "Research" }
 { command: "restore-session", id: "abc123", mode: "replace" }
+{ command: "import-sessions", data: [...] }  // Import with merge & dedup
 ```
 
 ### Content Script → Background

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,8 @@
     "tabGroups",
     "scripting",
     "idle",
-    "notifications"
+    "notifications",
+    "sidePanel"
   ],
   "optional_host_permissions": [
     "http://*/*",
@@ -31,6 +32,9 @@
       "48": "icons/icon-48.png",
       "128": "icons/icon-128.png"
     }
+  },
+  "side_panel": {
+    "default_path": "src/popup/popup.html"
   },
   "commands": {
     "unload-current": {

--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -13,7 +13,13 @@ import {
   reportTabMemory,
   setupMemoryCheckAlarm,
 } from "./memory-monitor.js";
-import { deleteSession, getSessions, restoreSession, saveSession } from "./session-manager.js";
+import {
+  deleteSession,
+  getSessions,
+  importSessions,
+  restoreSession,
+  saveSession,
+} from "./session-manager.js";
 import {
   cancelDomainSnooze,
   cancelTabSnooze,
@@ -47,20 +53,38 @@ import {
   isUrlWhitelisted,
 } from "./unload-manager.js";
 
-// Configure toolbar action based on user preference
+// Side-panel mode takes precedence over toolbarClickAction.
 async function configureToolbarAction() {
   const settings = await getSettings();
+  if (settings.useSidePanel && chrome.sidePanel) {
+    // Empty popup → action.onClicked fires → opens side panel.
+    chrome.action.setPopup({ popup: "" });
+    try {
+      await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false });
+    } catch {}
+    return;
+  }
   if (settings.toolbarClickAction === "popup") {
     chrome.action.setPopup({ popup: "src/popup/popup.html" });
   } else {
-    // Disable popup to enable onClicked event
     chrome.action.setPopup({ popup: "" });
+  }
+  if (chrome.sidePanel) {
+    try {
+      await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false });
+    } catch {}
   }
 }
 
-// Handle toolbar click (only fires when popup is empty)
-chrome.action.onClicked.addListener(async (_tab) => {
+// Toolbar click (only fires when popup is empty).
+chrome.action.onClicked.addListener(async (tab) => {
   const settings = await getSettings();
+  if (settings.useSidePanel && chrome.sidePanel) {
+    try {
+      await chrome.sidePanel.open({ windowId: tab.windowId });
+    } catch {}
+    return;
+  }
   switch (settings.toolbarClickAction) {
     case "discard-current":
       await discardCurrentTab();
@@ -446,7 +470,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
 // Handle messages from popup
 async function handleMessage(message) {
-  const { command, groupId, tabId, name, id, mode, minutes, domain, url } = message;
+  const { command, groupId, tabId, name, id, mode, minutes, domain, url, sessions } = message;
 
   switch (command) {
     case "unload-current":
@@ -476,6 +500,8 @@ async function handleMessage(message) {
       return await deleteSession(id);
     case "restore-session":
       return await restoreSession(id, mode);
+    case "import-sessions":
+      return await importSessions(sessions);
     // Stats commands
     case "get-stats":
       return await getStats();

--- a/src/background/session-manager.js
+++ b/src/background/session-manager.js
@@ -1,8 +1,11 @@
 // Session management module
 // Handles saving, restoring, and managing tab sessions
 
+import { isSafeHttpUrl } from "../shared/utils.js";
+
 const MAX_SESSIONS = 20;
 const SESSIONS_KEY = "tabrest_sessions";
+const SESSION_NAME_MAX_LEN = 100;
 
 // Internal protocols to exclude from sessions
 const INTERNAL_PROTOCOLS = ["chrome:", "chrome-extension:", "about:", "file:", "devtools:"];
@@ -61,7 +64,7 @@ export async function saveSession(name) {
 
   const session = {
     id: `session_${Date.now()}`,
-    name: name || formatSessionName(),
+    name: (name || formatSessionName()).slice(0, SESSION_NAME_MAX_LEN),
     createdAt: Date.now(),
     tabs: validTabs.map((t) => ({
       url: t.url,
@@ -144,4 +147,63 @@ export async function restoreSession(id, mode = "open") {
   }
 
   return { success: true, count: validTabs.length };
+}
+
+/**
+ * Import sessions from a parsed payload. Additive — duplicates by name and
+ * malformed entries are skipped. Hard-caps at MAX_SESSIONS overall.
+ * @param {Array} incoming
+ * @returns {Promise<{added: number, skipped: number}>}
+ */
+export async function importSessions(incoming) {
+  if (!Array.isArray(incoming)) return { added: 0, skipped: 0 };
+
+  const existing = await getSessions();
+  const existingNames = new Set(existing.map((s) => s.name));
+  let added = 0;
+  let skipped = 0;
+
+  for (const s of incoming) {
+    if (existing.length >= MAX_SESSIONS) {
+      skipped++;
+      continue;
+    }
+    if (!s || typeof s !== "object" || !s.name || !Array.isArray(s.tabs)) {
+      skipped++;
+      continue;
+    }
+    const name = String(s.name).slice(0, SESSION_NAME_MAX_LEN);
+    if (existingNames.has(name)) {
+      skipped++;
+      continue;
+    }
+
+    const tabs = s.tabs
+      .filter((t) => t && isSafeHttpUrl(t?.url))
+      .map((t) => ({
+        url: t.url,
+        title: typeof t.title === "string" ? t.title : "Untitled",
+        favIconUrl: typeof t.favIconUrl === "string" ? t.favIconUrl : "",
+        pinned: !!t.pinned,
+      }));
+
+    if (!tabs.length) {
+      skipped++;
+      continue;
+    }
+
+    existing.unshift({
+      id: `session_${Date.now()}_${crypto.randomUUID()}`,
+      name,
+      createdAt: typeof s.createdAt === "number" ? s.createdAt : Date.now(),
+      tabs,
+    });
+    existingNames.add(name);
+    added++;
+  }
+
+  if (added > 0) {
+    await chrome.storage.local.set({ [SESSIONS_KEY]: existing });
+  }
+  return { added, skipped };
 }

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -254,6 +254,17 @@ h2 {
   border-color: var(--secondary);
 }
 
+.btn.btn-sm {
+  padding: 6px 12px;
+  font-size: 13px;
+}
+
+.list-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+
 .stats-display {
   display: flex;
   gap: 24px;

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -60,6 +60,13 @@
           <option value="discard-others" data-i18n="actionDiscardOthers">Discard other tabs</option>
         </select>
       </div>
+      <div class="setting">
+        <label>
+          <input type="checkbox" id="use-side-panel">
+          <span data-i18n="useSidePanel">Open in side panel instead of popup</span>
+        </label>
+        <p class="help" data-i18n="useSidePanelHelp">Side panel stays open across tab switches. Requires Chrome 114+.</p>
+      </div>
     </section>
 
     <section class="card">
@@ -237,6 +244,10 @@
         <input type="text" id="new-whitelist" data-i18n-placeholder="addPlaceholder" placeholder="example.com">
         <button id="add-whitelist" class="btn" data-i18n="add">Add</button>
       </div>
+      <div class="list-actions">
+        <button class="btn btn-sm secondary" id="export-whitelist" data-i18n="exportList">Export</button>
+        <button class="btn btn-sm secondary" id="import-whitelist" data-i18n="importList">Import</button>
+      </div>
     </section>
 
     <section class="card">
@@ -246,6 +257,10 @@
       <div class="add-domain">
         <input type="text" id="new-blacklist" data-i18n-placeholder="addPlaceholder" placeholder="example.com">
         <button id="add-blacklist" class="btn" data-i18n="add">Add</button>
+      </div>
+      <div class="list-actions">
+        <button class="btn btn-sm secondary" id="export-blacklist" data-i18n="exportList">Export</button>
+        <button class="btn btn-sm secondary" id="import-blacklist" data-i18n="importList">Import</button>
       </div>
     </section>
 

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,6 +1,7 @@
 import { SETTINGS_DEFAULTS } from "../shared/constants.js";
 import { localizeHtml, t } from "../shared/i18n.js";
 import { injectIcons } from "../shared/icons.js";
+import { exportPayload, parseImport } from "../shared/import-export.js";
 import {
   hasHostPermission,
   removeHostPermission,
@@ -18,6 +19,7 @@ const elements = {
   threshold: document.getElementById("threshold"),
   minTabs: document.getElementById("min-tabs"),
   toolbarAction: document.getElementById("toolbar-action"),
+  useSidePanel: document.getElementById("use-side-panel"),
   saveYouTube: document.getElementById("save-youtube"),
   skipWhenOffline: document.getElementById("skip-when-offline"),
   restoreScroll: document.getElementById("restore-scroll"),
@@ -45,6 +47,10 @@ const elements = {
   blacklistContainer: document.getElementById("blacklist-container"),
   newBlacklist: document.getElementById("new-blacklist"),
   addBlacklist: document.getElementById("add-blacklist"),
+  exportWhitelist: document.getElementById("export-whitelist"),
+  importWhitelist: document.getElementById("import-whitelist"),
+  exportBlacklist: document.getElementById("export-blacklist"),
+  importBlacklist: document.getElementById("import-blacklist"),
   totalUnloaded: document.getElementById("total-unloaded"),
   totalSaved: document.getElementById("total-saved"),
   resetStats: document.getElementById("reset-stats"),
@@ -84,6 +90,7 @@ async function loadSettings() {
     radio.checked = radio.value === currentSettings.powerMode;
   }
   elements.toolbarAction.value = currentSettings.toolbarClickAction;
+  elements.useSidePanel.checked = currentSettings.useSidePanel ?? false;
   elements.saveYouTube.checked = currentSettings.saveYouTubeTimestamp;
   elements.skipWhenOffline.checked = currentSettings.skipWhenOffline;
   elements.restoreScroll.checked = currentSettings.restoreScrollPosition;
@@ -182,6 +189,7 @@ function setupEventListeners() {
     { el: elements.perTabMemory, key: "perTabJsHeapThresholdMB", type: "number" },
     { el: elements.minTabs, key: "minTabsBeforeAutoDiscard", type: "number" },
     { el: elements.toolbarAction, key: "toolbarClickAction", type: "string" },
+    { el: elements.useSidePanel, key: "useSidePanel", type: "checkbox" },
     { el: elements.saveYouTube, key: "saveYouTubeTimestamp", type: "checkbox" },
     { el: elements.skipWhenOffline, key: "skipWhenOffline", type: "checkbox" },
     { el: elements.restoreScroll, key: "restoreScrollPosition", type: "checkbox" },
@@ -276,6 +284,24 @@ function setupEventListeners() {
     if (e.key === "Enter") addBlacklistDomain();
   });
 
+  for (const { listKey, render, exportEl, importEl } of [
+    {
+      listKey: "whitelist",
+      render: renderWhitelist,
+      exportEl: elements.exportWhitelist,
+      importEl: elements.importWhitelist,
+    },
+    {
+      listKey: "blacklist",
+      render: renderBlacklist,
+      exportEl: elements.exportBlacklist,
+      importEl: elements.importBlacklist,
+    },
+  ]) {
+    exportEl.addEventListener("click", () => exportList(listKey));
+    importEl.addEventListener("click", () => importList(listKey, render));
+  }
+
   // Reset stats
   elements.resetStats.addEventListener("click", async () => {
     await chrome.storage.local.set({ stats: { tabsUnloaded: 0, memorySaved: 0 } });
@@ -319,6 +345,45 @@ async function addDomainToList(inputEl, listKey, renderFn) {
   inputEl.value = "";
   renderFn();
   showStatus(t("domainAdded"));
+}
+
+// Export a domain list (whitelist | blacklist) to clipboard.
+async function exportList(listKey) {
+  try {
+    await exportPayload(listKey, { entries: currentSettings[listKey] || [] });
+    showStatus(t("exportedToClipboard"));
+  } catch {
+    showStatus(t("exportFailed"));
+  }
+}
+
+// Import a domain list from clipboard text. Additive — duplicates and invalid
+// entries are skipped, never overwritten.
+async function importList(listKey, renderFn) {
+  const text = prompt(t("pasteImportJson"));
+  if (!text) return;
+  const result = parseImport(text, listKey);
+  if (!result.ok) {
+    showStatus(t(`importFailed_${result.error}`));
+    return;
+  }
+  const entries = Array.isArray(result.data.entries) ? result.data.entries : [];
+  let added = 0;
+  let skipped = 0;
+  for (const raw of entries) {
+    const entry = String(raw || "")
+      .trim()
+      .toLowerCase();
+    if (!isValidDomainOrIp(entry) || currentSettings[listKey].includes(entry)) {
+      skipped++;
+      continue;
+    }
+    currentSettings[listKey].push(entry);
+    added++;
+  }
+  if (added > 0) await saveSettings(currentSettings);
+  renderFn();
+  showStatus(t("importedNAdded", [String(added), String(skipped)]));
 }
 
 // Add domain to whitelist

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -1028,6 +1028,16 @@ footer {
   overflow-y: auto;
 }
 
+.sessions-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.sessions-actions .btn {
+  flex: 1;
+}
+
 .session-card {
   display: flex;
   align-items: center;
@@ -1245,4 +1255,19 @@ footer {
 
 ::-webkit-scrollbar-thumb:hover {
   background: var(--text-muted);
+}
+
+/* Side panel mode: viewport is full window height (~700px+), much taller than
+ * popup max (~600px). Stretch container and widen body slightly. */
+@media (min-height: 650px) {
+  body {
+    width: auto;
+    min-width: 350px;
+    max-width: 100%;
+    min-height: 100vh;
+  }
+
+  .container {
+    min-height: 100vh;
+  }
 }

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -210,6 +210,10 @@
           <div class="session-list" id="session-list">
             <div class="empty-state" data-i18n="saveFirstSession">Save your first session</div>
           </div>
+          <div class="sessions-actions">
+            <button class="btn btn-sm" id="export-sessions" data-i18n="exportSessions">Export Sessions</button>
+            <button class="btn btn-sm" id="import-sessions" data-i18n="importSessions">Import Sessions</button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -1,6 +1,7 @@
 import { sanitizeString } from "../shared/error-reporter.js";
 import { localizeHtml, t } from "../shared/i18n.js";
 import { icon, injectIcons } from "../shared/icons.js";
+import { exportPayload, parseImport } from "../shared/import-export.js";
 import {
   collectDiagnostics,
   formatDiagnosticsJSON,
@@ -9,7 +10,7 @@ import {
 import { requestHostPermission } from "../shared/permissions.js";
 import { getSettings, saveSettings } from "../shared/storage.js";
 import { initTheme, onThemeChange, toggleTheme, updateThemeIcon } from "../shared/theme.js";
-import { formatBytes, getBrowserInfo } from "../shared/utils.js";
+import { formatBytes, getBrowserInfo, isSafeHttpUrl } from "../shared/utils.js";
 
 // DOM Elements
 const elements = {
@@ -54,6 +55,8 @@ const elements = {
   sessionList: document.getElementById("session-list"),
   sessionNameInput: document.getElementById("session-name-input"),
   btnSaveSession: document.getElementById("btn-save-session"),
+  exportSessions: document.getElementById("export-sessions"),
+  importSessions: document.getElementById("import-sessions"),
   // Detailed stats
   statToday: document.getElementById("stat-today"),
   statAllTime: document.getElementById("stat-all-time"),
@@ -405,17 +408,6 @@ async function renderTabList() {
   renderFilteredTabs(filterTabs(tabs));
 }
 
-// Validate URL is safe (http/https only)
-function isSafeUrl(url) {
-  if (!url) return false;
-  try {
-    const parsed = new URL(url);
-    return parsed.protocol === "http:" || parsed.protocol === "https:";
-  } catch {
-    return false;
-  }
-}
-
 // Render sessions list
 async function renderSessions() {
   const sessions = await sendCommand("get-sessions");
@@ -431,7 +423,7 @@ async function renderSessions() {
       const favicons = s.tabs
         .slice(0, 4)
         .map((tab) =>
-          tab.favIconUrl && isSafeUrl(tab.favIconUrl)
+          tab.favIconUrl && isSafeHttpUrl(tab.favIconUrl)
             ? `<img src="${escapeHtml(tab.favIconUrl)}" alt="">`
             : "",
         )
@@ -787,6 +779,31 @@ function setupEventListeners() {
     } else {
       showToast(result.error || t("failedToSave"));
     }
+  });
+
+  // Session export — copy current sessions as JSON to clipboard
+  elements.exportSessions?.addEventListener("click", async () => {
+    const sessions = (await sendCommand("get-sessions")) || [];
+    try {
+      await exportPayload("sessions", { sessions });
+      showToast(t("exportedToClipboard"));
+    } catch {
+      showToast(t("exportFailed"));
+    }
+  });
+
+  // Session import — parse pasted JSON, additive merge by name
+  elements.importSessions?.addEventListener("click", async () => {
+    const text = prompt(t("pasteImportJson"));
+    if (!text) return;
+    const result = parseImport(text, "sessions");
+    if (!result.ok) {
+      showToast(t(`importFailed_${result.error}`));
+      return;
+    }
+    const res = await sendCommand("import-sessions", { sessions: result.data.sessions });
+    showToast(t("importedNAdded", [String(res?.added || 0), String(res?.skipped || 0)]));
+    await renderSessions();
   });
 
   // Session list event delegation

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -38,6 +38,8 @@ export const SETTINGS_DEFAULTS = {
   showSuspendWarning: true,
   // Delay between toast appearance and discard, in ms
   suspendWarningDelayMs: 3000,
+  // Open in side panel instead of popup
+  useSidePanel: false,
 };
 
 // YouTube timestamp storage key

--- a/src/shared/import-export.js
+++ b/src/shared/import-export.js
@@ -1,0 +1,43 @@
+// Clipboard-based import/export helpers shared by options + popup.
+// Schema: { version, type, ...payload }. Bumping IMPORT_EXPORT_VERSION on
+// breaking format changes lets older exports still be detected and rejected.
+
+export const IMPORT_EXPORT_VERSION = 1;
+
+/**
+ * Serialize a payload and copy it to the clipboard.
+ * @param {string} type - Logical kind: "whitelist" | "blacklist" | "sessions".
+ * @param {object} data - Type-specific fields (entries, sessions, etc.).
+ * @returns {Promise<string>} The JSON string written to clipboard.
+ */
+export async function exportPayload(type, data) {
+  const payload = { version: IMPORT_EXPORT_VERSION, type, ...data };
+  const text = JSON.stringify(payload, null, 2);
+  await navigator.clipboard.writeText(text);
+  return text;
+}
+
+/**
+ * Parse + validate an imported JSON string.
+ * @param {string} text - Raw clipboard / textarea contents.
+ * @param {string} expectedType - Type the caller expects (e.g. "whitelist").
+ * @returns {{ok: true, data: object} | {ok: false, error: string}}
+ */
+export function parseImport(text, expectedType) {
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return { ok: false, error: "invalidJson" };
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { ok: false, error: "invalidShape" };
+  }
+  if (parsed.version !== IMPORT_EXPORT_VERSION) {
+    return { ok: false, error: "unsupportedVersion" };
+  }
+  if (parsed.type !== expectedType) {
+    return { ok: false, error: "wrongType" };
+  }
+  return { ok: true, data: parsed };
+}

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -104,6 +104,18 @@ export function isMinorOrMajorBump(prev, curr) {
   return false;
 }
 
+// True only for http(s) URLs. Used to gate any code path that loads or
+// restores a URL from untrusted input (saved sessions, imports, favicons).
+export function isSafeHttpUrl(url) {
+  if (typeof url !== "string" || !url) return false;
+  try {
+    const { protocol } = new URL(url);
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 // Format bytes to human readable string
 export function formatBytes(bytes) {
   if (!bytes || bytes === 0) return "0 B";

--- a/tests/shared/import-export.test.js
+++ b/tests/shared/import-export.test.js
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  exportPayload,
+  IMPORT_EXPORT_VERSION,
+  parseImport,
+} from "../../src/shared/import-export.js";
+
+describe("parseImport", () => {
+  it("rejects invalid JSON", () => {
+    expect(parseImport("not json", "whitelist")).toEqual({ ok: false, error: "invalidJson" });
+  });
+
+  it("rejects null / arrays / non-objects", () => {
+    expect(parseImport("null", "whitelist")).toEqual({ ok: false, error: "invalidShape" });
+    expect(parseImport("[]", "whitelist")).toEqual({ ok: false, error: "invalidShape" });
+    expect(parseImport('"a"', "whitelist")).toEqual({ ok: false, error: "invalidShape" });
+  });
+
+  it("rejects unsupported version", () => {
+    const text = JSON.stringify({ version: 99, type: "whitelist", entries: [] });
+    expect(parseImport(text, "whitelist")).toEqual({ ok: false, error: "unsupportedVersion" });
+  });
+
+  it("rejects mismatched type", () => {
+    const text = JSON.stringify({
+      version: IMPORT_EXPORT_VERSION,
+      type: "blacklist",
+      entries: [],
+    });
+    expect(parseImport(text, "whitelist")).toEqual({ ok: false, error: "wrongType" });
+  });
+
+  it("accepts a valid payload", () => {
+    const payload = {
+      version: IMPORT_EXPORT_VERSION,
+      type: "whitelist",
+      entries: ["example.com"],
+    };
+    const result = parseImport(JSON.stringify(payload), "whitelist");
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual(payload);
+  });
+});
+
+describe("exportPayload", () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, "navigator", {
+      value: { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } },
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it("writes JSON with version + type to clipboard", async () => {
+    const text = await exportPayload("sessions", { sessions: [{ name: "a", tabs: [] }] });
+    const parsed = JSON.parse(text);
+    expect(parsed.version).toBe(IMPORT_EXPORT_VERSION);
+    expect(parsed.type).toBe("sessions");
+    expect(parsed.sessions).toEqual([{ name: "a", tabs: [] }]);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(text);
+  });
+});


### PR DESCRIPTION
## Summary

Closes Sprint 3 of the parity plan with two opt-in P3 features. All 10 cherry-picked phases now shipped.

### Phase 09 — Side Panel
- New `sidePanel` permission + `side_panel.default_path` in `manifest.json`
- `useSidePanel: false` setting (opt-in via options page)
- `configureToolbarAction` extended: when ON, popup is disabled and `chrome.action.onClicked` opens `chrome.sidePanel`
- Popup CSS media query (`min-height: 650px`) stretches container to full panel viewport — same HTML/JS reused, no duplicate

### Phase 10 — Whitelist / Blacklist / Sessions Import-Export
- New `src/shared/import-export.js` with versioned schema `{ version: 1, type, ...payload }` and validating `parseImport`
- Whitelist + blacklist export/import in options (additive merge, dedupe via existing `isValidDomainOrIp`)
- Sessions export/import in popup; new background `import-sessions` command + `importSessions` in `session-manager.js`
- Imported tab URLs gated to `http`/`https` via shared `isSafeHttpUrl` helper

### Cross-cutting
- 13 i18n keys (en + vi)
- 6 new vitest tests for `parseImport` / `exportPayload` (total **119/119 pass**)
- Simplify pass: deduped `isSafeHttpUrl` (used by popup favicons + session import); removed redundant `chrome.windows.onFocusChanged` listener; consolidated session name truncation; trimmed restate-the-code comments

## Test plan

- [ ] `pnpm run ci` → manifest valid, biome clean, 119/119 tests pass
- [ ] Load unpacked → toggle "Open in side panel" → click toolbar → side panel opens
- [ ] Toggle off → click toolbar → popup opens (existing behavior preserved)
- [ ] Options → Whitelist → Export → paste into Import → "Added 0, skipped N" (dedupe works)
- [ ] Options → Whitelist → Import malformed JSON → "Import failed: invalid JSON"
- [ ] Options → Whitelist → Import a blacklist payload → "Import failed: wrong type for this list"
- [ ] Popup → Sessions → Save a session → Export → clipboard contains `{version:1, type:"sessions", sessions:[...]}`
- [ ] Popup → Sessions → Import same payload → "Added 0, skipped 1" (dedupe by name)
- [ ] Popup → Sessions → Import session containing `javascript:` URL → URL filtered out
- [ ] Verify badge counter still updates on tab discard/restore (no regression from focus listener removal)
- [ ] Manual: load extension on Chrome 113 (no `chrome.sidePanel`) → toggle is no-op, popup mode still works