### PR TITLE
fix(background): open side panel on toolbar click when enabled

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -56,35 +56,24 @@ import {
 // Side-panel mode takes precedence over toolbarClickAction.
 async function configureToolbarAction() {
   const settings = await getSettings();
-  if (settings.useSidePanel && chrome.sidePanel) {
-    // Empty popup → action.onClicked fires → opens side panel.
+  // Native auto-open: sidePanel.open() loses its user-gesture token after awaiting settings.
+  const useSidePanel = settings.useSidePanel && Boolean(chrome.sidePanel);
+  if (useSidePanel || settings.toolbarClickAction !== "popup") {
     chrome.action.setPopup({ popup: "" });
-    try {
-      await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false });
-    } catch {}
-    return;
-  }
-  if (settings.toolbarClickAction === "popup") {
-    chrome.action.setPopup({ popup: "src/popup/popup.html" });
   } else {
-    chrome.action.setPopup({ popup: "" });
+    chrome.action.setPopup({ popup: "src/popup/popup.html" });
   }
   if (chrome.sidePanel) {
     try {
-      await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false });
+      await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: useSidePanel });
     } catch {}
   }
 }
 
-// Toolbar click (only fires when popup is empty).
+// Toolbar click (only fires when popup is empty AND side-panel auto-open is off).
 chrome.action.onClicked.addListener(async (tab) => {
   const settings = await getSettings();
-  if (settings.useSidePanel && chrome.sidePanel) {
-    try {
-      await chrome.sidePanel.open({ windowId: tab.windowId });
-    } catch {}
-    return;
-  }
+  if (settings.useSidePanel) return;
   switch (settings.toolbarClickAction) {
     case "discard-current":
       await discardCurrentTab();


### PR DESCRIPTION
## Summary
- Clicking the extension icon did not open the side panel when **Open in side panel instead of popup** was enabled.
- Root cause: `await getSettings()` inside the `chrome.action.onClicked` listener consumed the user-gesture token, so `chrome.sidePanel.open()` threw — silently swallowed by an empty `catch {}`.
- Fix: set `openPanelOnActionClick: true` when side-panel mode is on, so Chrome opens the panel natively on toolbar click — no manual `open()` needed, no user-gesture race.
- Also unified the two `setPanelBehavior` branches (only differed by the boolean) and simplified the popup-vs-empty selection.

## Test plan
- [x] Reload extension at `chrome://extensions`
- [x] In Options, enable **Open in side panel instead of popup** → click the toolbar icon → side panel opens
- [x] Disable the setting → toolbar icon opens the popup (or runs the configured discard action when popup mode is off)
- [x] Toggle the setting back and forth in a session → toolbar behavior switches each time without reload