### PR TITLE
fix(popup): sidepanel and popup UX issues

### DIFF
--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -327,6 +327,13 @@ footer {
   opacity: 0.9;
 }
 
+.filter-chip.disabled,
+.filter-chip:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
 [data-theme="dark"] .filter-chip {
   background: rgba(255, 255, 255, 0.1);
   border-color: rgba(255, 255, 255, 0.2);
@@ -396,6 +403,7 @@ footer {
 .tab-details {
   display: flex;
   flex-direction: column;
+  flex: 1;
   min-width: 0;
 }
 
@@ -459,6 +467,13 @@ footer {
   z-index: 100;
   box-shadow: var(--shadow);
   min-width: 90px;
+}
+
+/* Flip up when not enough space below */
+.snooze-dropdown.flip-up .snooze-menu {
+  top: auto;
+  bottom: 100%;
+  margin-bottom: 4px;
 }
 
 .snooze-dropdown.open .snooze-menu {
@@ -720,7 +735,8 @@ footer {
 }
 
 .section-body-inner {
-  padding: 2px 10px 10px;
+  padding: 10px;
+  border-top: 1px solid var(--border);
 }
 
 /* Quick Actions Row */
@@ -860,6 +876,7 @@ footer {
 
 .more-actions-grid .btn {
   flex: 1;
+  min-width: 0;
 }
 
 /* Footer */
@@ -1269,5 +1286,21 @@ footer {
 
   .container {
     min-height: 100vh;
+  }
+
+  /* Let tab list grow taller in side panel and scroll inside */
+  #tabs-body.open {
+    max-height: 65vh;
+  }
+
+  .tab-list {
+    max-height: calc(65vh - 80px);
+  }
+}
+
+/* Wider side panel: take advantage of horizontal space when user widens panel */
+@media (min-height: 650px) and (min-width: 480px) {
+  .stats-grid {
+    grid-template-columns: repeat(4, 1fr);
   }
 }

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -175,10 +175,10 @@
         <div class="section-body-inner">
           <div class="more-actions-grid">
             <button class="btn btn-sm" id="unload-right">
-              <span>Unload Right →</span>
+              <span>Unload&nbsp;Right&nbsp;→</span>
             </button>
             <button class="btn btn-sm" id="unload-left">
-              <span>← Unload Left</span>
+              <span>←&nbsp;Unload&nbsp;Left</span>
             </button>
             <button class="btn btn-sm" id="close-duplicates">
               <span data-icon="copy"></span>
@@ -207,9 +207,7 @@
               <span data-i18n="save">Save</span>
             </button>
           </div>
-          <div class="session-list" id="session-list">
-            <div class="empty-state" data-i18n="saveFirstSession">Save your first session</div>
-          </div>
+          <div class="session-list" id="session-list"></div>
           <div class="sessions-actions">
             <button class="btn btn-sm" id="export-sessions" data-i18n="exportSessions">Export Sessions</button>
             <button class="btn btn-sm" id="import-sessions" data-i18n="importSessions">Import Sessions</button>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -82,9 +82,13 @@ const elements = {
 
 // --- Utility Functions ---
 
-// Send command to background script
 async function sendCommand(command, data = {}) {
   return await chrome.runtime.sendMessage({ command, ...data });
+}
+
+// Heuristic must stay in sync with the @media (min-height: 650px) rule in popup.css
+function isSidePanel() {
+  return window.matchMedia("(min-height: 650px)").matches;
 }
 
 // Get hostname from URL
@@ -321,6 +325,17 @@ function updateFilterCounts(tabs) {
   elements.filterCountSleeping.textContent = counts.sleeping;
   elements.filterCountSnoozed.textContent = counts.snoozed;
   elements.filterCountProtected.textContent = counts.protected;
+
+  setChipDisabled("sleeping", counts.sleeping === 0);
+  setChipDisabled("snoozed", counts.snoozed === 0);
+  setChipDisabled("protected", counts.protected === 0);
+}
+
+function setChipDisabled(filter, disabled) {
+  const chip = document.querySelector(`.filter-chip[data-filter="${filter}"]`);
+  if (!chip) return;
+  chip.classList.toggle("disabled", disabled);
+  chip.disabled = disabled;
 }
 
 // Apply search query (case-insensitive substring on title or url)
@@ -347,7 +362,7 @@ function renderTabItem(tab) {
   const favicon = tab.favIconUrl
     ? `<img class="tab-favicon" src="${tab.favIconUrl}" alt="">`
     : `<span class="tab-favicon-placeholder">${icon("globe", 14)}</span>`;
-  const title = escapeHtml(tab.title.length > 30 ? `${tab.title.slice(0, 30)}...` : tab.title);
+  const title = escapeHtml(tab.title);
   const hostname = getHostname(tab.url);
   const snoozeBtn =
     tab.active || tab.discarded
@@ -413,7 +428,7 @@ async function renderSessions() {
   const sessions = await sendCommand("get-sessions");
 
   if (!sessions?.length) {
-    elements.sessionList.innerHTML = `<div class="empty-state">${t("saveFirstSession")}</div>`;
+    elements.sessionList.innerHTML = "";
     return;
   }
 
@@ -610,7 +625,7 @@ function setupEventListeners() {
   // Filter chips click handler
   elements.tabFilters.addEventListener("click", (e) => {
     const chip = e.target.closest(".filter-chip");
-    if (!chip) return;
+    if (!chip || chip.disabled) return;
 
     // Update active state
     for (const c of document.querySelectorAll(".filter-chip")) {
@@ -635,14 +650,22 @@ function setupEventListeners() {
     const item = e.target.closest(".tab-item");
     if (!item) return;
 
-    // Handle snooze dropdown toggle
-    if (e.target.classList.contains("tab-snooze-btn") && !e.target.classList.contains("unsnooze")) {
+    const snoozeBtn = e.target.closest(".tab-snooze-btn");
+    if (snoozeBtn && !snoozeBtn.classList.contains("unsnooze")) {
       e.stopPropagation();
-      const dropdown = e.target.closest(".snooze-dropdown");
+      const dropdown = snoozeBtn.closest(".snooze-dropdown");
       if (dropdown) {
-        // Close other dropdowns
         for (const d of document.querySelectorAll(".snooze-dropdown.open")) {
-          d.classList.remove("open");
+          d.classList.remove("open", "flip-up");
+        }
+        dropdown.classList.remove("flip-up");
+        const btnRect = snoozeBtn.getBoundingClientRect();
+        const containerRect = elements.tabList.getBoundingClientRect();
+        const spaceBelow = containerRect.bottom - btnRect.bottom;
+        const spaceAbove = btnRect.top - containerRect.top;
+        // Menu is ~180px tall — flip up only when below is too tight and above has more room
+        if (spaceBelow < 200 && spaceAbove > spaceBelow) {
+          dropdown.classList.add("flip-up");
         }
         dropdown.classList.toggle("open");
       }
@@ -650,11 +673,12 @@ function setupEventListeners() {
     }
 
     // Handle unsnooze
-    if (e.target.classList.contains("unsnooze")) {
+    const unsnoozeBtn = e.target.closest(".unsnooze");
+    if (unsnoozeBtn) {
       e.stopPropagation();
-      const tabId = Number.parseInt(e.target.dataset.tabId, 10);
-      const snoozeType = e.target.dataset.snoozeType;
-      const snoozeDomain = e.target.dataset.snoozeDomain;
+      const tabId = Number.parseInt(unsnoozeBtn.dataset.tabId, 10);
+      const snoozeType = unsnoozeBtn.dataset.snoozeType;
+      const snoozeDomain = unsnoozeBtn.dataset.snoozeDomain;
 
       if (snoozeType === "domain" && snoozeDomain) {
         await sendCommand("cancel-domain-snooze", { domain: snoozeDomain });
@@ -689,16 +713,17 @@ function setupEventListeners() {
       return;
     }
 
-    if (e.target.classList.contains("tab-unload-btn")) {
+    const unloadBtn = e.target.closest(".tab-unload-btn");
+    if (unloadBtn) {
       e.stopPropagation();
-      const tabId = Number.parseInt(e.target.dataset.tabId, 10);
+      const tabId = Number.parseInt(unloadBtn.dataset.tabId, 10);
       await sendCommand("unload-tab", { tabId });
       await Promise.all([renderTabList(), updateStats()]);
       showToast(t("tabUnloaded"));
     } else if (!e.target.closest(".snooze-dropdown")) {
       const tabId = Number.parseInt(item.dataset.tabId, 10);
       await chrome.tabs.update(tabId, { active: true });
-      window.close();
+      if (!isSidePanel()) window.close();
     }
   });
 
@@ -914,6 +939,29 @@ async function init() {
     checkFormPermBanner(),
   ]);
   setupEventListeners();
+
+  // Popup re-renders on every open; side panel persists, so it must subscribe to tab changes.
+  if (isSidePanel()) setupTabEventSync();
+}
+
+function setupTabEventSync() {
+  let pending = false;
+  const scheduleRefresh = () => {
+    if (pending) return;
+    pending = true;
+    setTimeout(() => {
+      pending = false;
+      renderTabList();
+    }, 150);
+  };
+  chrome.tabs.onActivated.addListener(scheduleRefresh);
+  chrome.tabs.onUpdated.addListener((_id, changeInfo) => {
+    if ("discarded" in changeInfo || "title" in changeInfo || "favIconUrl" in changeInfo) {
+      scheduleRefresh();
+    }
+  });
+  chrome.tabs.onRemoved.addListener(scheduleRefresh);
+  chrome.tabs.onCreated.addListener(scheduleRefresh);
 }
 
 init();


### PR DESCRIPTION
## Summary
- Fix side panel closing when clicking a tab; list now auto-syncs on tab activity
- Fix unload/snooze icon clicks falling through to tab activation (event target was inner SVG)
- Flip snooze dropdown upward when near bottom of list (no more cut-off menu)
- Drop hard 30-char title truncation so wide side panel shows full titles
- Polish: 4-col stats grid in wide panel, header/body spacing, disabled filter chips when count = 0, no-wrap on Unload Right/Left arrows, remove redundant Sessions empty state

## Test plan
- [x] Open popup: title truncates with ellipsis, arrows don't wrap, filter chips with count 0 are dimmed
- [x] Open side panel: click tab → tab activates, panel stays open, list refreshes
- [x] Click moon icon on a tab → unloads (does not activate tab)
- [x] Click snooze icon on bottom tab → menu flips up, fully visible
- [x] Resize side panel wider → stats grid becomes 4 columns
- [x] Sessions section: no "Save your first session" duplicate text below the input