### PR TITLE
fix(options): request host permission for discarded-tab prefix toggle

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -334,8 +334,12 @@
     "description": "Label for prefix input"
   },
   "prefixHelp": {
-    "message": "Does not work on protected pages (Chrome Web Store, Google accounts, etc.)",
+    "message": "Requires website access permission. Does not work on protected pages (Chrome Web Store, Google accounts, etc.)",
     "description": "Help text for prefix setting"
+  },
+  "prefixPermDenied": {
+    "message": "Tab prefix requires website access permission. Toggle skipped.",
+    "description": "Toast when user denies optional host permission for discarded-tab prefix"
   },
   "minTabsLabel": {
     "message": "Only auto-unload when inactive tabs exceed:",
@@ -553,7 +557,7 @@
     "description": "Toast when user denies optional host permission for form protection"
   },
   "formPermBannerText": {
-    "message": "Form protection was reset due to permission changes.",
+    "message": "Site permissions were reset. Enable to restore affected settings.",
     "description": "Banner shown after upgrade when host permission was implicitly revoked"
   },
   "enable": {
@@ -561,7 +565,7 @@
     "description": "Generic enable button label"
   },
   "formPermGranted": {
-    "message": "Form protection enabled",
+    "message": "Settings restored",
     "description": "Toast after user grants permission via recovery banner"
   },
   "showSuspendWarningLabel": {

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -248,7 +248,10 @@
     "message": "Ký hiệu:"
   },
   "prefixHelp": {
-    "message": "Không hoạt động trên các trang được bảo vệ (Chrome Web Store, tài khoản Google, v.v.)"
+    "message": "Cần quyền truy cập website. Không hoạt động trên các trang được bảo vệ (Chrome Web Store, tài khoản Google, v.v.)"
+  },
+  "prefixPermDenied": {
+    "message": "Tiền tố tab cần quyền truy cập website. Đã bỏ qua."
   },
   "minTabsLabel": {
     "message": "Chỉ tự động dỡ khi số tab không hoạt động vượt quá:"
@@ -413,13 +416,13 @@
     "message": "Bảo vệ form cần quyền truy cập website. Đã bỏ qua."
   },
   "formPermBannerText": {
-    "message": "Bảo vệ form đã bị tắt do thay đổi quyền."
+    "message": "Quyền truy cập website đã bị đặt lại. Bật để khôi phục các tuỳ chọn liên quan."
   },
   "enable": {
     "message": "Bật"
   },
   "formPermGranted": {
-    "message": "Đã bật bảo vệ form"
+    "message": "Đã khôi phục tuỳ chọn"
   },
   "showSuspendWarningLabel": {
     "message": "Hiển thị cảnh báo trước khi tự động tạm dừng"

--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -1,6 +1,6 @@
 import { ALARM_NAMES, FORM_CHECK_TIMEOUT_MS } from "../shared/constants.js";
 import { initErrorReporter } from "../shared/error-reporter.js";
-import { hasHostPermission } from "../shared/permissions.js";
+import { HOST_PERM_DEPENDENT_FLAGS, hasHostPermission } from "../shared/permissions.js";
 import { getSettings, saveSettings } from "../shared/storage.js";
 import { isMinorOrMajorBump, isValidDomainOrIp, unwrapHostname } from "../shared/utils.js";
 import { clearInjectedTab, ensureFormCheckerInjected } from "./form-injector.js";
@@ -96,8 +96,8 @@ chrome.runtime.onStartup.addListener(async () => {
   await configureToolbarAction();
   await setupSnoozeCleanupAlarm();
   // Catch the case where the user revoked host permission via chrome://extensions
-  // between sessions; silently flip protectFormTabs off (no banner — not an upgrade).
-  await syncFormPermissionState(false);
+  // between sessions; silently flip dependent toggles off (no banner — not an upgrade).
+  await syncHostPermissionState(false);
   await discardAllTabsOnStartup();
   updateBadge();
 });
@@ -131,19 +131,21 @@ chrome.runtime.onInstalled.addListener(async (details) => {
     await chrome.storage.local.set({ tabrest_lastVersion: currentVersion });
   }
 
-  // Migrate users moving to optional_host_permissions: if form protection was on
-  // but Chrome dropped the implicit grant, force-disable and queue recovery banner.
-  await syncFormPermissionState(details.reason === "update");
+  // Migrate users moving to optional_host_permissions: if any host-permission-
+  // dependent toggle was on but Chrome dropped the implicit grant, force-disable
+  // and queue recovery banner.
+  await syncHostPermissionState(details.reason === "update");
 });
 
-async function syncFormPermissionState(showBannerIfChanged) {
+async function syncHostPermissionState(showBannerIfChanged) {
   if (await hasHostPermission()) return;
   const settings = await getSettings();
-  if (!settings.protectFormTabs) return;
-  settings.protectFormTabs = false;
+  const reset = HOST_PERM_DEPENDENT_FLAGS.filter((key) => settings[key]);
+  if (reset.length === 0) return;
+  for (const key of reset) settings[key] = false;
   await saveSettings(settings);
   if (showBannerIfChanged) {
-    await chrome.storage.local.set({ pendingFormPermBanner: true });
+    await chrome.storage.local.set({ pendingHostPermBanner: reset });
   }
 }
 

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -3,6 +3,7 @@ import { localizeHtml, t } from "../shared/i18n.js";
 import { injectIcons } from "../shared/icons.js";
 import { exportPayload, parseImport } from "../shared/import-export.js";
 import {
+  HOST_PERM_DEPENDENT_FLAGS,
   hasHostPermission,
   removeHostPermission,
   requestHostPermission,
@@ -77,7 +78,8 @@ async function init() {
 
 // Load settings into UI
 async function loadSettings() {
-  currentSettings = await getSettings();
+  const [settings, hasHost] = await Promise.all([getSettings(), hasHostPermission()]);
+  currentSettings = settings;
 
   elements.autoStartup.checked = currentSettings.autoUnloadOnStartup;
   elements.timer.value = currentSettings.unloadDelayMinutes;
@@ -99,8 +101,8 @@ async function loadSettings() {
   updateIdleThresholdVisibility();
   elements.unloadPinned.checked = currentSettings.unloadPinnedTabs;
   elements.protectAudio.checked = currentSettings.protectAudioTabs;
-  // protectFormTabs is only truly enabled when host permission is granted.
-  elements.protectForm.checked = currentSettings.protectFormTabs && (await hasHostPermission());
+  // protectFormTabs / showDiscardedPrefix only truly enabled when host permission is granted.
+  elements.protectForm.checked = currentSettings.protectFormTabs && hasHost;
   elements.showBadge.checked = currentSettings.showBadgeCount;
   elements.notifyAutoUnload.checked = currentSettings.notifyOnAutoUnload;
   elements.showSuspendWarning.checked = currentSettings.showSuspendWarning;
@@ -108,7 +110,7 @@ async function loadSettings() {
   updateSuspendWarningDelayVisibility();
   elements.enableStats.checked = currentSettings.enableStats;
   elements.enableTabGroups.checked = currentSettings.enableTabGroups;
-  elements.showDiscardedPrefix.checked = currentSettings.showDiscardedPrefix;
+  elements.showDiscardedPrefix.checked = currentSettings.showDiscardedPrefix && hasHost;
   elements.discardedPrefix.value = currentSettings.discardedPrefix;
   updatePrefixInputVisibility();
   elements.enableErrorReporting.checked = currentSettings.enableErrorReporting ?? true;
@@ -187,6 +189,32 @@ async function loadStats() {
   elements.totalSaved.textContent = formatBytes(stats.memorySaved || 0);
 }
 
+// Bind a checkbox to a host-permission-dependent setting: request permission on
+// enable, revert + toast on deny, and only revoke when no other dependent flag
+// is still on.
+function bindHostPermToggle(el, settingKey, denyMessageKey, onChange) {
+  el.addEventListener("change", async () => {
+    if (el.checked) {
+      const granted = await requestHostPermission();
+      if (!granted) {
+        el.checked = false;
+        showStatus(t(denyMessageKey));
+        return;
+      }
+    } else {
+      // Re-read storage in case another surface (e.g., popup banner) flipped a
+      // sibling flag while options was open.
+      const fresh = await getSettings();
+      const stillNeeded = HOST_PERM_DEPENDENT_FLAGS.some((k) => k !== settingKey && fresh[k]);
+      if (!stillNeeded) await removeHostPermission();
+    }
+    currentSettings[settingKey] = el.checked;
+    await saveSettings(currentSettings);
+    if (onChange) onChange();
+    showStatus(t("settingsSaved"));
+  });
+}
+
 // Setup event listeners
 function setupEventListeners() {
   // Auto-save settings on change
@@ -211,7 +239,6 @@ function setupEventListeners() {
     { el: elements.suspendWarningDelay, key: "suspendWarningDelayMs", type: "number" },
     { el: elements.enableStats, key: "enableStats", type: "checkbox" },
     { el: elements.enableTabGroups, key: "enableTabGroups", type: "checkbox" },
-    { el: elements.showDiscardedPrefix, key: "showDiscardedPrefix", type: "checkbox" },
     { el: elements.enableErrorReporting, key: "enableErrorReporting", type: "checkbox" },
   ];
 
@@ -226,9 +253,6 @@ function setupEventListeners() {
       }
       await saveSettings(currentSettings);
       showStatus(t("settingsSaved"));
-      if (key === "showDiscardedPrefix") {
-        updatePrefixInputVisibility();
-      }
       if (key === "onlyDiscardWhenIdle") {
         updateIdleThresholdVisibility();
       }
@@ -238,23 +262,10 @@ function setupEventListeners() {
     });
   }
 
-  // protectFormTabs has its own handler — it must request optional host permission
-  // before enabling, and revert the toggle if the user denies.
-  elements.protectForm.addEventListener("change", async () => {
-    if (elements.protectForm.checked) {
-      const granted = await requestHostPermission();
-      if (!granted) {
-        elements.protectForm.checked = false;
-        showStatus(t("formProtectPermDenied"));
-        return;
-      }
-    } else {
-      await removeHostPermission();
-    }
-    currentSettings.protectFormTabs = elements.protectForm.checked;
-    await saveSettings(currentSettings);
-    showStatus(t("settingsSaved"));
-  });
+  bindHostPermToggle(elements.protectForm, "protectFormTabs", "formProtectPermDenied");
+  bindHostPermToggle(elements.showDiscardedPrefix, "showDiscardedPrefix", "prefixPermDenied", () =>
+    updatePrefixInputVisibility(),
+  );
 
   // Power mode radios
   for (const radio of elements.powerModeRadios) {

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -521,23 +521,30 @@ function hideReviewPrompt() {
   elements.reviewPrompt.style.display = "none";
 }
 
+async function readPendingHostPermFlags() {
+  const { pendingHostPermBanner } = await chrome.storage.local.get("pendingHostPermBanner");
+  return Array.isArray(pendingHostPermBanner) && pendingHostPermBanner.length
+    ? pendingHostPermBanner
+    : null;
+}
+
 async function checkFormPermBanner() {
-  const { pendingFormPermBanner } = await chrome.storage.local.get("pendingFormPermBanner");
-  if (!pendingFormPermBanner) return;
+  if (!(await readPendingHostPermFlags())) return;
   elements.formPermBanner.style.display = "flex";
   injectIcons();
 }
 
 async function dismissFormPermBanner() {
   elements.formPermBanner.style.display = "none";
-  await chrome.storage.local.remove("pendingFormPermBanner");
+  await chrome.storage.local.remove("pendingHostPermBanner");
 }
 
 async function handleFormPermGrant() {
+  const flags = await readPendingHostPermFlags();
   const granted = await requestHostPermission();
-  if (granted) {
+  if (granted && flags?.length) {
     const settings = await getSettings();
-    settings.protectFormTabs = true;
+    for (const key of flags) settings[key] = true;
     await saveSettings(settings);
     showToast(t("formPermGranted"));
   }

--- a/src/shared/permissions.js
+++ b/src/shared/permissions.js
@@ -1,7 +1,11 @@
 // Helpers for the optional host permission ("http://*/*", "https://*/*").
-// Used by form protection. YouTube tracker keeps its narrow static match.
+// Used by form protection and the discarded-tab title prefix.
 
 const HOST_ORIGINS = ["http://*/*", "https://*/*"];
+
+// Settings flags that require the optional host permission to function.
+// Toggles share the grant; the permission is revoked only when all are off.
+export const HOST_PERM_DEPENDENT_FLAGS = ["protectFormTabs", "showDiscardedPrefix"];
 
 // Cache the permission state per session: `chrome.permissions.contains` is an
 // async IPC fired once per discard candidate / popup form check / per-tab heap


### PR DESCRIPTION
## Summary
- Fix bug where enabling **Prepend symbol to discarded tabs** did not actually add the prefix: title injection requires the optional host permission, but the toggle never requested it (only `protectFormTabs` did).
- Share the host permission grant between `protectFormTabs` and `showDiscardedPrefix` — request on enable, revoke only when both are off.
- Extend host-perm migration / recovery banner to cover both flags; affected flags are stored in `pendingHostPermBanner` so the popup banner restores exactly what was reset.
- Hoist `HOST_PERM_DEPENDENT_FLAGS` to `src/shared/permissions.js`; generalise recovery-banner copy and add `prefixPermDenied` toast (en + vi).

## Test plan
- [x] Fresh profile, no host permission: enable **Prepend symbol** in options → Chrome prompts for `http://*/*`, `https://*/*`; on grant, discarded tab titles get the symbol prefix.
- [x] Deny the prompt → toggle reverts and `prefixPermDenied` toast shows.
- [x] Enable both **Prepend symbol** and **Form protection** → disabling one keeps host permission (verify via `chrome://extensions`); disabling both revokes it.
- [x] Revoke host permission via `chrome://extensions`, restart Chrome → both flags are silently disabled (no banner).
- [x] Trigger via update path (`onInstalled` reason `update`) → popup shows recovery banner; clicking **Enable** restores both flags.
- [x] `pnpm lint && pnpm test` clean (119/119).