### PR TITLE
docs: add feature self-test checklist + remove sprint Phase labels

### DIFF
--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -234,7 +234,7 @@ async function injectFormChecker(tabId, settings) {
 
 ```javascript
 // Explain non-obvious business logic
-// Phase 5: Apply power mode multiplier to delay
+// Apply power mode multiplier to delay
 const effectiveDelay =
   settings.unloadDelayMinutes * powerConfig.delayMultiplier;
 
@@ -298,7 +298,7 @@ async function handleUpdate() {
 ## Import/Export Schema Versioning
 
 ```javascript
-// Phase 10: Versioned schemas for forward compatibility
+// Versioned schemas for forward compatibility
 export const EXPORT_SCHEMA_VERSION = 1;
 
 export function validateImportData(importedData) {

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -119,8 +119,8 @@ service-worker.js (orchestrator)
   onlyDiscardWhenIdle: boolean,
   idleThresholdMinutes: number,
   skipWhenOffline: boolean,
-  useSidePanel: boolean,             // Phase 09: side panel mode toggle
-  showSuspendWarning: boolean,       // Phase 08: pre-discard toast
+  useSidePanel: boolean,             // side panel mode toggle
+  showSuspendWarning: boolean,       // pre-discard toast
   suspendWarningDelayMs: number,     // 3000ms default
   // ... see constants.js SETTINGS_DEFAULTS for complete list
 }
@@ -144,8 +144,9 @@ service-worker.js (orchestrator)
 ```
 
 ### Other Storage Keys (chrome.storage.local)
-- `popup_section_state` — Persistent collapse state for popup sections (Phase 03)
-- `tabrest_lastVersion` — Current version for changelog gating (Phase 06)
+
+- `popup_section_state` — Persistent collapse state for popup sections
+- `tabrest_lastVersion` — Current version for changelog gating
 - `tabrest_snooze` — Active snooze timers
 - `tabrest_scroll_positions` — Cached scroll positions (max 100)
 - `youtube_timestamps` — YouTube playback positions (7-day max age)

--- a/docs/feature-test-checklist.md
+++ b/docs/feature-test-checklist.md
@@ -1,0 +1,344 @@
+# TabRest Feature Self-Test Checklist
+
+Periodic manual QA checklist covering every user-visible feature. Run before each release, after major refactors, or whenever Chrome updates the extension APIs.
+
+- **Scope:** v0.0.4 (Sprint 1–3 complete)
+- **Estimated time:** 60–90 minutes for a full pass
+- **Browser:** Chrome (or Chromium-based) latest stable
+- **Locale coverage:** Verify both `en` and `vi` for any UI string changes
+
+## How to Use
+
+1. Load the extension as **Unpacked** from `chrome://extensions` (Developer mode on).
+2. Open the service worker DevTools: `chrome://extensions` → TabRest → "Inspect views: service worker".
+3. Walk through each section. Tick `[x]` when the expected result is observed; mark `[!]` and add a note if something fails.
+4. Reset state between sections where indicated (e.g., reset stats, clear whitelist).
+
+Legend: `[ ]` not tested · `[x]` pass · `[!]` fail · `[~]` skip / N/A.
+
+---
+
+## 0. Pre-flight
+
+- [ ] Reload the unpacked extension; service worker boots without errors in DevTools console.
+- [ ] `chrome://extensions/?errors=<id>` is empty for TabRest.
+- [ ] Onboarding page opens automatically on first install (incognito profile or fresh user data dir).
+- [ ] Toolbar icon and badge render at 16/48/128 px.
+- [ ] Open popup → header shows logo, version, theme toggle, settings cog.
+- [ ] Open Options → all sections render without overflow at 1280×800.
+- [ ] Switch language to `vi` (Chrome → Settings → Languages → set Vietnamese as primary, then reload extension); popup + options strings reflect Vietnamese.
+- [ ] Switch back to `en`; strings revert.
+
+## 1. Auto-Unload — Inactivity Timer
+
+- [ ] Set `Unload after` = 1 min (Options → Auto-Unload), `Min inactive tabs before discard` = 0.
+- [ ] Open 3 tabs (any non-whitelisted sites). Focus tab A.
+- [ ] Wait 1 min while staying on tab A.
+- [ ] Tabs B and C are discarded (favicon dimmed, prefix shown). Tab A stays loaded.
+- [ ] Click discarded tab B → reloads instantly, scroll position preserved (if `restoreScrollPosition` on).
+- [ ] Set delay = 0 → auto-unload disabled; verify tabs no longer discard after a minute.
+
+## 2. Auto-Unload — Memory Threshold
+
+- [ ] Set `Memory threshold` = 60% (Options → Memory Management).
+- [ ] Open enough tabs to push RAM > 60% (or temporarily lower threshold to current RAM −5%).
+- [ ] Within 30s, LRU tabs discard until RAM drops below threshold.
+- [ ] Set threshold = 0 → memory-based discarding disabled.
+
+## 3. Auto-Unload — Per-Tab JS Heap Limit
+
+- [ ] Set `Per-tab JS heap limit` = 100 MB (Options).
+- [ ] If the form-checker host permission was previously granted, `chrome.scripting` injects the heap reporter; otherwise verify the recovery banner appears in the popup.
+- [ ] Open a heavy site (e.g., Figma, large Google Sheet) and wait > 30s.
+- [ ] Tab discards once heap > 100 MB.
+- [ ] Set limit = 0 → heap monitoring disabled.
+
+## 4. Auto-Unload — Startup
+
+- [ ] Toggle `Auto-unload on startup` ON (Options).
+- [ ] Quit and relaunch Chrome with multiple tabs open from previous session.
+- [ ] All non-active, non-whitelisted tabs discard within seconds of startup.
+- [ ] Toggle OFF → tabs remain loaded after relaunch.
+
+## 5. Min Inactive Tabs Threshold
+
+- [ ] Set `Min inactive tabs before auto-discard` = 5.
+- [ ] With < 5 inactive tabs, auto-unload does NOT fire even if delay elapsed.
+- [ ] Open more tabs to exceed threshold → auto-unload resumes.
+
+## 6. Idle-Only Mode
+
+- [ ] Toggle `Only auto-unload when idle` ON; `Idle threshold` = 1 min.
+- [ ] Keep typing/moving mouse → no auto-unload triggers.
+- [ ] Stop interaction for ≥ 1 min → auto-unload runs on next alarm.
+- [ ] Toggle OFF → auto-unload runs regardless of idle state.
+
+## 7. Skip When Offline
+
+- [ ] Toggle `Skip when offline` ON.
+- [ ] Disconnect network (DevTools → Network → Offline, or disable Wi-Fi).
+- [ ] Wait beyond `unloadDelayMinutes` → no tabs discard.
+- [ ] Reconnect → discards resume on next alarm.
+
+## 8. Power Mode
+
+- [ ] Switch to **Battery saver**: aggressive thresholds; longer delays.
+- [ ] Switch to **Normal**: defaults applied.
+- [ ] Switch to **Performance**: shortest intervals, highest priority discard.
+- [ ] After each switch, verify alarm period changes (DevTools `chrome.alarms.getAll`).
+
+## 9. Manual Controls — Popup Buttons
+
+- [ ] **Unload Current** → discards focused tab; popup closes; tab shows prefix.
+- [ ] **Unload Others** → all tabs except active discard.
+- [ ] **More Actions → Unload Right** → only tabs to right of active discard.
+- [ ] **More Actions → Unload Left** → only tabs to left.
+- [ ] **More Actions → Close Duplicates** → in a window with 3+ duplicate URLs, the oldest is kept and the rest close.
+- [ ] Per-tab "Unload" icon in tab list discards only that row.
+
+## 10. Keyboard Shortcuts
+
+Configurable at `chrome://extensions/shortcuts`.
+
+- [ ] `Alt+Shift+D` — unload current tab.
+- [ ] `Alt+Shift+O` — unload other tabs.
+- [ ] `Alt+Shift+→` — unload tabs to the right.
+- [ ] `Alt+Shift+←` — unload tabs to the left.
+- [ ] Rebind one shortcut → still fires the correct command.
+
+## 11. Toolbar Click Action
+
+- [ ] `popup` (default) → click icon opens popup.
+- [ ] `discard-current` → click icon discards active tab; no popup.
+- [ ] `discard-others` → click icon discards all other tabs.
+- [ ] Setting takes effect after Options save without service-worker reload.
+
+## 12. Context Menu
+
+- [ ] Right-click on any page → TabRest submenu visible.
+- [ ] "Unload this tab" works.
+- [ ] "Add domain to whitelist" adds the page's hostname (incl. localhost or IP).
+- [ ] "Snooze this tab (1h)" + "Snooze this site (1h)" entries fire correctly.
+- [ ] Right-click on a link → "Open link in suspended state" creates a discarded tab.
+
+## 13. Tab Search
+- [ ] Click search toggle in popup → input appears, focused.
+- [ ] Type substring → tab list filters by title and URL (case-insensitive).
+- [ ] Combined with filter chips (All / Sleeping / Snoozed / Protected) → AND intersection.
+- [ ] Clear input → full list returns.
+- [ ] Close & reopen popup → search input collapses back (does not persist value).
+
+## 14. Filter Chips
+
+- [ ] **All** chip shows every tab.
+- [ ] **Sleeping** shows only discarded tabs.
+- [ ] **Snoozed** shows tabs/domains under snooze.
+- [ ] **Protected** shows pinned/audio/form/whitelisted tabs with badge icons.
+- [ ] Counts on each chip update live as tabs change state.
+
+## 15. Persistent Section State
+- [ ] Collapse "Sessions", "More Actions", and "Stats" sections.
+- [ ] Close popup. Reopen popup → previously collapsed sections stay collapsed.
+- [ ] Open them, close popup, reopen → expanded state persists.
+- [ ] Same behaviour in side panel mode.
+
+## 16. Whitelist (incl. localhost & IP)
+
+- [ ] Add `youtube.com` via Options text field → whitelist saves; visiting youtube.com is protected from auto-unload.
+- [ ] Add `localhost` → tabs on `http://localhost:*` protected.
+- [ ] Add `127.0.0.1` → tabs on `http://127.0.0.1:*` protected.
+- [ ] Add `::1` (IPv6) → protected.
+- [ ] Invalid entry (e.g., `http://`) → input shows error, not saved.
+- [ ] Remove an entry → next auto-unload may discard that domain.
+- [ ] Context menu "Add to whitelist" on a localhost or IP tab works end-to-end.
+
+## 17. Blacklist
+
+- [ ] Add a low-priority domain to blacklist.
+- [ ] Tabs on that domain discard on the very next timer tick (ignoring delay).
+- [ ] Removing entry stops aggressive discard.
+
+## 18. Pinned / Audio / Form Protection
+
+- [ ] Pinned tab + `Protect pinned tabs` ON → never discards via auto-unload.
+- [ ] Tab playing YouTube audio + `Protect audio tabs` ON → never discards.
+- [ ] Tab with unsaved form (e.g., partially filled Google Form) + `Protect form tabs` ON → not discarded; popup row shows "Form" badge.
+- [ ] Disable a protection → matching tabs become eligible.
+- [ ] **Force unload** (per-tab menu in popup) overrides all protections.
+
+## 19. Optional Host Permissions + Form Injector
+- [ ] On a fresh install, host permissions NOT granted by default.
+- [ ] Toggle `Protect form tabs` OFF then ON → permission prompt or recovery banner appears.
+- [ ] Grant permission → form-checker injects only on tabs accessed; verify in popup row badges and DevTools.
+- [ ] Revoke via `chrome://extensions` → recovery banner reappears in popup with "Enable" CTA.
+- [ ] Toggle `Discarded tab title prefix` ON → if `scripting`/host perms not granted, requests them.
+
+## 20. Snooze
+
+- [ ] Snooze a tab for 30 min → shows "Snoozed" badge; auto-unload skips it.
+- [ ] Snooze a domain for 1 h → all current and new tabs on that domain protected.
+- [ ] Cancel snooze → tab/domain returns to normal eligibility.
+- [ ] Snooze persists across browser restart (within window).
+- [ ] Snooze expires automatically when the timer elapses.
+
+## 21. Suspend Warning Toast
+- [ ] Toggle `Show suspend warning` ON; delay = 3000 ms.
+- [ ] Open a tab and let it become eligible for auto-unload.
+- [ ] Toast appears in-page 3 s before the discard fires.
+- [ ] Switching to the tab cancels the discard.
+- [ ] Starting audio/video, modifying a form, or snoozing within the 3 s also cancels.
+- [ ] Toggle OFF → no toast; tab discards silently.
+- [ ] Custom delay (e.g., 5000 ms) honored.
+
+## 22. YouTube Timestamp Restore
+
+- [ ] Toggle `Save YouTube timestamp` ON.
+- [ ] Play a YouTube video to 1:00 then unload the tab.
+- [ ] Reload the discarded tab → playback resumes ≥ 0:55.
+- [ ] Visit > 7 days later → cache expired (manual: edit `chrome.storage.sync` to confirm).
+
+## 23. Scroll Position Restore
+
+- [ ] Toggle `Restore scroll position` ON.
+- [ ] Scroll halfway down a long page; let tab discard.
+- [ ] Re-open tab → restores within ±50 px of original scroll position.
+- [ ] Cap of 100 entries: discard 110 distinct tabs and verify the oldest entries drop from `tabrest_scroll_positions` (chrome.storage.local).
+
+## 24. Tab Groups
+
+- [ ] Create a tab group with 3 tabs.
+- [ ] Popup `Tab groups` selector lists the group with tab count.
+- [ ] "Unload this group" discards every tab in the group while keeping the group structure.
+- [ ] Toggle `Enable tab groups` OFF → selector hidden.
+
+## 25. Visual Indicators
+
+- [ ] Badge count = number of discarded tabs (toggle `Show badge count`).
+- [ ] Discarded tab title prefix shows configured glyph (default `💤`); custom glyph (max 4 chars) saves and applies after the host permission prompt.
+- [ ] Toggle prefix OFF → titles unchanged on next discard.
+- [ ] Popup header RAM percentage updates every ~5 s.
+
+## 26. Memory Estimate Tooltip
+- [ ] Hover the RAM stat in popup → tooltip explains the estimate (e.g., "~150 MB per discarded tab").
+- [ ] Tooltip text localized in `vi`.
+- [ ] Tooltip dismisses on mouse-out.
+
+## 27. Notifications
+
+- [ ] Toggle `Notify on auto-unload` ON.
+- [ ] Trigger an auto-unload → desktop notification with tab count + memory saved.
+- [ ] Notification respects OS focus-assist / Do Not Disturb.
+
+## 28. Statistics
+
+- [ ] After unloading several tabs, popup `Stats` shows correct today + all-time totals.
+- [ ] "RAM saved" estimate increases.
+- [ ] "Member since" reflects install date.
+- [ ] "Reset stats" zeroes counters and confirms via toast.
+
+## 29. Sessions
+
+- [ ] Save current window as session "test-1" (popup → Sessions → name → Save).
+- [ ] Close all tabs.
+- [ ] Restore "test-1" → exact tab list reopens (URLs match, order preserved).
+- [ ] Delete "test-1" → entry disappears.
+- [ ] 100+ saved sessions paginate or scroll without breaking the popup layout.
+
+## 30. Import / Export
+
+For each of: **whitelist**, **blacklist**, **sessions**:
+
+- [ ] Export → JSON copied to clipboard with `version: 1` schema.
+- [ ] Empty the list, then Import the previously exported JSON → list restored, no duplicates.
+- [ ] Import a JSON with overlap → additive merge, dedup by name (sessions) or domain (whitelist/blacklist).
+- [ ] Malformed JSON → error toast, no state change.
+- [ ] Wrong schema version → rejected with clear message.
+
+## 31. Side Panel Mode
+
+- [ ] Options → Toolbar Action → enable `Open in side panel`.
+- [ ] Click toolbar icon → side panel opens (popup does not).
+- [ ] Side panel layout responsive at 360 px and 480 px wide.
+- [ ] Side panel stays open while switching tabs and windows.
+- [ ] Disable side panel → toolbar reverts to popup.
+- [ ] All popup interactions (search, filter, snooze, save session, import/export) work in side panel.
+
+## 32. Auto-Open Changelog
+
+- [ ] Bump manifest version from `0.0.4` → `0.0.5` (patch). Reload extension → changelog tab does NOT auto-open.
+- [ ] Bump from `0.0.4` → `0.1.0` (minor) → changelog page opens in new tab.
+- [ ] Bump from `0.1.0` → `1.0.0` (major) → changelog opens.
+- [ ] Restore version; clear `tabrest_lastVersion` from `chrome.storage.local` to retest.
+
+## 33. Theme (Dark / Light)
+
+- [ ] Toggle dark mode in popup → applies instantly.
+- [ ] Open Options in another window → already in dark mode (cross-page sync).
+- [ ] Toggle in Options → popup follows.
+- [ ] Onboarding & changelog pages match the chosen theme.
+- [ ] OS dark mode preference is respected on first install.
+
+## 34. Bug Report / Error Reporting
+
+- [ ] Click "Report a bug" in popup footer → modal opens with auto-filled diagnostics (extension version, Chrome version, platform).
+- [ ] Submit → opens the GitHub issue link with prefilled body.
+- [ ] Toggle `Send anonymous error reports` OFF → service-worker errors are NOT exfiltrated (verify no outbound network in DevTools).
+- [ ] Toggle ON → errors collected via `error-reporter.js` and surfaced (manual: throw a test error).
+
+## 35. Onboarding
+
+- [ ] Fresh install → onboarding tab opens automatically.
+- [ ] Walks through key features and links to Options.
+- [ ] Theme matches user preference.
+
+## 36. i18n Coverage
+
+- [ ] Switch Chrome UI language to Vietnamese.
+- [ ] Every string in popup, options, onboarding, changelog, toast, notification, error message renders in Vietnamese (no `__MSG_*__` placeholders, no fallback English unless intentional).
+- [ ] Numbers/dates use locale-appropriate formatting.
+
+## 37. Settings Sync
+
+- [ ] Sign in to Chrome with a sync-enabled account.
+- [ ] Modify settings on Profile A; on Profile B (signed in same account) verify sync within ~1 min.
+- [ ] Sessions and whitelist propagate across devices (sessions stored in `chrome.storage.sync`).
+- [ ] Tab activity stays per-device (`chrome.storage.local`).
+
+## 38. Service Worker Resilience
+
+- [ ] In DevTools → Application → Service Workers → click "Stop" to terminate the worker.
+- [ ] Wait > 30s. Open a tab, then idle.
+- [ ] Worker auto-wakes via `chrome.alarms`; auto-unload still fires.
+- [ ] Long sessions (≥ 4 h) do not leak memory (`chrome://serviceworker-internals` shows stable heap).
+
+## 39. Cross-Browser Smoke (Chromium variants)
+
+Spot-check on:
+
+- [ ] Brave latest
+- [ ] Edge latest
+- [ ] Vivaldi latest
+- [ ] Opera latest
+
+Verify popup loads, manual unload works, side panel renders (where supported), shortcuts respond.
+
+## 40. Uninstall / Cleanup
+
+- [ ] Remove extension → all alarms cleared.
+- [ ] Storage entries cleaned up by Chrome (verify via fresh reinstall: stats reset, no leftover snooze/sessions).
+- [ ] No orphaned content scripts in previously injected tabs after reinstall.
+
+---
+
+## Issue Reporting Template
+
+When a check fails, file an issue with:
+
+- Section + checklist item ID (e.g., `§21 Suspend Warning Toast`).
+- Steps reproduced.
+- Expected vs actual.
+- Browser + OS + extension version.
+- Service worker DevTools console excerpt.
+- Screenshots or screen recording where helpful.
+
+Repository: <https://github.com/lamngockhuong/tabrest/issues>

--- a/docs/project-overview-pdr.md
+++ b/docs/project-overview-pdr.md
@@ -108,21 +108,24 @@ optional_host_permissions: http://*/*, https://*/*
 
 **10 new features across 3 sprints:**
 
-**Sprint 1: Quick Wins**
-- Phase 01: Close duplicate tabs in window
-- Phase 02: Tab search with live filtering (title + URL)
-- Phase 03: Persistent popup section state
-- Phase 04: Whitelist localhost & IP addresses
-- Phase 05: Memory estimate tooltip on RAM stats
+#### Sprint 1: Quick Wins
 
-**Sprint 2: UX Optimization**
-- Phase 06: Auto-open changelog on minor/major updates (skip patches)
-- Phase 07: Optional host permissions + on-demand form-checker injection
-- Phase 08: Suspend warning toast (3s delay before auto-suspend)
+- Close duplicate tabs in window
+- Tab search with live filtering (title + URL)
+- Persistent popup section state
+- Whitelist localhost & IP addresses
+- Memory estimate tooltip on RAM stats
 
-**Sprint 3: Major Features**
-- Phase 09: Chrome side panel UI (alternative to popup)
-- Phase 10: Import/export whitelists, blacklists, and sessions to clipboard
+#### Sprint 2: UX Optimization
+
+- Auto-open changelog on minor/major updates (skip patches)
+- Optional host permissions + on-demand form-checker injection
+- Suspend warning toast (3s delay before auto-suspend)
+
+#### Sprint 3: Major Features
+
+- Chrome side panel UI (alternative to popup)
+- Import/export whitelists, blacklists, and sessions to clipboard
 
 | Version | Status  | Key Changes |
 | ------- | ------- | --------------------------------------------------- |

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -103,21 +103,24 @@
 
 ### v0.0.4 (Current - 10 Features Complete)
 
-**Sprint 1: Quick Wins** (Phases 01-05)
-- **Phase 01:** Close duplicate tabs — one-click dedup in popup "More Actions"
-- **Phase 02:** Tab search — live filter by title + URL, composable with status chips
-- **Phase 03:** Persistent section state — collapse/expand state remembered across popup closes
-- **Phase 04:** Whitelist localhost & IP — support `localhost`, IPv4, IPv6 in whitelist/blacklist
-- **Phase 05:** Memory estimate tooltip — hover RAM stats for per-tab memory breakdown
+#### Sprint 1: Quick Wins
 
-**Sprint 2: UX Optimization** (Phases 06-08)
-- **Phase 06:** Changelog auto-open — only on minor/major bumps, silent for patches (no noise)
-- **Phase 07:** Optional host permissions — moved to `optional_host_permissions`; form-checker injected on-demand via `chrome.scripting.executeScript()`; permission recovery banner on update
-- **Phase 08:** Suspend warning toast — 3s on-page warning before auto-discard, re-check protections after delay, configurable delay
+- Close duplicate tabs — one-click dedup in popup "More Actions"
+- Tab search — live filter by title + URL, composable with status chips
+- Persistent section state — collapse/expand state remembered across popup closes
+- Whitelist localhost & IP — support `localhost`, IPv4, IPv6 in whitelist/blacklist
+- Memory estimate tooltip — hover RAM stats for per-tab memory breakdown
 
-**Sprint 3: Bigger Features** (Phases 09-10)
-- **Phase 09:** Side panel UI — Chrome side panel alternative to popup, reuses popup.html/js/css, stays open across tabs, responsive layout
-- **Phase 10:** Import/export — clipboard-based JSON for whitelists, blacklists, and sessions; versioned schema for forward compat; merge strategy on import
+#### Sprint 2: UX Optimization
+
+- Changelog auto-open — only on minor/major bumps, silent for patches (no noise)
+- Optional host permissions — moved to `optional_host_permissions`; form-checker injected on-demand via `chrome.scripting.executeScript()`; permission recovery banner on update
+- Suspend warning toast — 3s on-page warning before auto-discard, re-check protections after delay, configurable delay
+
+#### Sprint 3: Bigger Features
+
+- Side panel UI — Chrome side panel alternative to popup, reuses popup.html/js/css, stays open across tabs, responsive layout
+- Import/export — clipboard-based JSON for whitelists, blacklists, and sessions; versioned schema for forward compat; merge strategy on import
 
 ### v0.0.3
 - Added tab filter chips (All/Sleeping/Snoozed/Protected)

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -269,7 +269,7 @@ service-worker.js
 
 ## Advanced Features (v0.0.4+)
 
-### Side Panel Architecture (Phase 09)
+### Side Panel Architecture
 
 **Design:**
 
@@ -290,7 +290,7 @@ service-worker.js
 - Background response format identical for both UI surfaces
 - State shared via `chrome.storage.local` (e.g., filter state, section collapse)
 
-### Optional Host Permissions & On-Demand Injection (Phase 07)
+### Optional Host Permissions & On-Demand Injection
 
 **Flow:**
 
@@ -308,7 +308,7 @@ service-worker.js
 - Reduced trust friction on install (optional rather than required)
 - Form-checker stays lazy; only loaded when needed
 
-### Suspend Warning Toast (Phase 08)
+### Suspend Warning Toast
 
 **Execution:**
 
@@ -330,7 +330,7 @@ service-worker.js
 - Settings: `showSuspendWarning`, `suspendWarningDelayMs`
 - No persistent state for warnings (ephemeral toast)
 
-### Import/Export (Phase 10)
+### Import/Export
 
 **Schema:**
 

--- a/docs/vi/feature-test-checklist.md
+++ b/docs/vi/feature-test-checklist.md
@@ -1,0 +1,344 @@
+# Checklist Tự Kiểm Tra Tính Năng TabRest
+
+Checklist QA thủ công định kỳ, bao quát mọi tính năng người dùng nhìn thấy. Chạy trước mỗi lần phát hành, sau khi refactor lớn, hoặc khi Chrome cập nhật API extension.
+
+- **Phạm vi:** v0.0.4 (đã hoàn thành Sprint 1–3)
+- **Thời lượng ước tính:** 60–90 phút cho một lượt đầy đủ
+- **Trình duyệt:** Chrome (hoặc nhân Chromium) bản stable mới nhất
+- **Bao phủ ngôn ngữ:** Kiểm tra cả `en` và `vi` cho mọi thay đổi chuỗi UI
+
+## Cách sử dụng
+
+1. Tải extension dạng **Unpacked** từ `chrome://extensions` (bật Developer mode).
+2. Mở DevTools của service worker: `chrome://extensions` → TabRest → "Inspect views: service worker".
+3. Đi qua từng mục. Đánh `[x]` khi đạt kết quả mong đợi; đánh `[!]` và ghi chú nếu lỗi.
+4. Reset trạng thái giữa các mục khi được chỉ định (ví dụ: reset thống kê, xóa whitelist).
+
+Ký hiệu: `[ ]` chưa test · `[x]` đạt · `[!]` lỗi · `[~]` bỏ qua / không áp dụng.
+
+---
+
+## 0. Pre-flight
+
+- [ ] Tải lại extension; service worker khởi động không lỗi trong DevTools console.
+- [ ] `chrome://extensions/?errors=<id>` trống cho TabRest.
+- [ ] Trang onboarding tự mở khi cài lần đầu (profile ẩn danh hoặc data dir mới).
+- [ ] Icon trên toolbar và badge hiển thị đúng ở 16/48/128 px.
+- [ ] Mở popup → header có logo, version, nút theme, biểu tượng cài đặt.
+- [ ] Mở Options → mọi section render gọn ở 1280×800.
+- [ ] Đổi ngôn ngữ sang `vi` (Chrome → Settings → Languages → đặt tiếng Việt làm chính, reload extension); chuỗi popup + options chuyển sang tiếng Việt.
+- [ ] Đổi lại `en`; chuỗi quay lại tiếng Anh.
+
+## 1. Auto-Unload — Hẹn giờ không hoạt động
+
+- [ ] Đặt `Unload after` = 1 phút (Options → Auto-Unload), `Min inactive tabs before discard` = 0.
+- [ ] Mở 3 tab (site bất kỳ không nằm trong whitelist). Focus tab A.
+- [ ] Đợi 1 phút trên tab A.
+- [ ] Tab B và C bị discard (favicon mờ, có prefix). Tab A vẫn loaded.
+- [ ] Click tab B đã discard → tải lại tức thì, scroll giữ nguyên (nếu bật `restoreScrollPosition`).
+- [ ] Đặt delay = 0 → tắt auto-unload; xác nhận tab không còn discard sau 1 phút.
+
+## 2. Auto-Unload — Ngưỡng RAM
+
+- [ ] Đặt `Memory threshold` = 60% (Options → Memory Management).
+- [ ] Mở đủ tab để RAM > 60% (hoặc tạm hạ ngưỡng = RAM hiện tại −5%).
+- [ ] Trong 30s, tab LRU bị discard cho tới khi RAM tụt dưới ngưỡng.
+- [ ] Đặt threshold = 0 → tắt discard theo memory.
+
+## 3. Auto-Unload — Giới hạn JS Heap mỗi tab
+
+- [ ] Đặt `Per-tab JS heap limit` = 100 MB (Options).
+- [ ] Nếu host permission cho form-checker đã cấp trước đó, `chrome.scripting` inject reporter; ngược lại, banner phục hồi xuất hiện trong popup.
+- [ ] Mở site nặng (Figma, Google Sheet lớn) và đợi > 30s.
+- [ ] Tab discard khi heap > 100 MB.
+- [ ] Đặt limit = 0 → tắt giám sát heap.
+
+## 4. Auto-Unload — Khi khởi động
+
+- [ ] Bật `Auto-unload on startup` (Options).
+- [ ] Thoát Chrome rồi mở lại với nhiều tab từ phiên trước.
+- [ ] Mọi tab không active và không trong whitelist bị discard ngay sau khởi động.
+- [ ] Tắt → tab không discard sau khi mở lại.
+
+## 5. Ngưỡng số tab inactive tối thiểu
+
+- [ ] Đặt `Min inactive tabs before auto-discard` = 5.
+- [ ] Khi < 5 tab inactive, auto-unload KHÔNG chạy dù đã hết delay.
+- [ ] Mở thêm tab vượt ngưỡng → auto-unload tiếp tục.
+
+## 6. Chế độ chỉ chạy khi máy idle
+
+- [ ] Bật `Only auto-unload when idle`; `Idle threshold` = 1 phút.
+- [ ] Liên tục gõ phím / di chuột → không có auto-unload.
+- [ ] Ngưng tương tác ≥ 1 phút → auto-unload chạy ở alarm kế tiếp.
+- [ ] Tắt → auto-unload chạy bất kể idle.
+
+## 7. Bỏ qua khi offline
+
+- [ ] Bật `Skip when offline`.
+- [ ] Ngắt mạng (DevTools → Network → Offline, hoặc tắt Wi-Fi).
+- [ ] Đợi vượt `unloadDelayMinutes` → không tab nào discard.
+- [ ] Kết nối lại → discard tiếp tục ở alarm kế tiếp.
+
+## 8. Power Mode
+
+- [ ] Chuyển **Battery saver**: ngưỡng aggressive; delay dài hơn.
+- [ ] Chuyển **Normal**: dùng default.
+- [ ] Chuyển **Performance**: chu kỳ ngắn nhất, ưu tiên discard cao.
+- [ ] Sau mỗi lần chuyển, kiểm tra alarm period đổi (DevTools `chrome.alarms.getAll`).
+
+## 9. Điều khiển thủ công — Nút trong popup
+
+- [ ] **Unload Current** → discard tab đang focus; popup đóng; tab có prefix.
+- [ ] **Unload Others** → mọi tab khác active đều discard.
+- [ ] **More Actions → Unload Right** → chỉ tab bên phải tab active discard.
+- [ ] **More Actions → Unload Left** → chỉ tab bên trái.
+- [ ] **More Actions → Close Duplicates** → trong window có ≥ 3 URL trùng, giữ tab cũ nhất, đóng các tab còn lại.
+- [ ] Icon "Unload" mỗi dòng tab discard đúng tab đó.
+
+## 10. Phím tắt
+
+Cấu hình tại `chrome://extensions/shortcuts`.
+
+- [ ] `Alt+Shift+D` — unload tab hiện tại.
+- [ ] `Alt+Shift+O` — unload các tab khác.
+- [ ] `Alt+Shift+→` — unload tab bên phải.
+- [ ] `Alt+Shift+←` — unload tab bên trái.
+- [ ] Đổi binding một phím tắt → vẫn fire đúng lệnh.
+
+## 11. Hành động click toolbar
+
+- [ ] `popup` (mặc định) → click icon mở popup.
+- [ ] `discard-current` → click icon discard tab active; không popup.
+- [ ] `discard-others` → click icon discard mọi tab khác.
+- [ ] Đổi setting có hiệu lực ngay sau khi lưu Options, không cần reload service worker.
+
+## 12. Menu chuột phải
+
+- [ ] Right-click trên trang bất kỳ → submenu TabRest hiện ra.
+- [ ] "Unload this tab" hoạt động.
+- [ ] "Add domain to whitelist" thêm hostname trang đó (gồm localhost hoặc IP).
+- [ ] "Snooze this tab (1h)" + "Snooze this site (1h)" hoạt động.
+- [ ] Right-click trên link → "Open link in suspended state" tạo tab discarded.
+
+## 13. Tìm kiếm tab
+- [ ] Click toggle search trong popup → input xuất hiện và auto focus.
+- [ ] Gõ chuỗi con → danh sách lọc theo title và URL (không phân biệt hoa/thường).
+- [ ] Kết hợp filter chips (All / Sleeping / Snoozed / Protected) → giao (AND).
+- [ ] Xóa input → danh sách đầy đủ trở lại.
+- [ ] Đóng popup rồi mở lại → input thu lại (giá trị không lưu).
+
+## 14. Filter Chips
+
+- [ ] **All** hiển thị mọi tab.
+- [ ] **Sleeping** chỉ tab đã discard.
+- [ ] **Snoozed** tab/domain đang snooze.
+- [ ] **Protected** tab pinned/audio/form/whitelist với badge tương ứng.
+- [ ] Số đếm trên mỗi chip cập nhật trực tiếp khi tab đổi state.
+
+## 15. Ghi nhớ trạng thái section
+- [ ] Thu gọn các section "Sessions", "More Actions", "Stats".
+- [ ] Đóng popup. Mở lại → các section trên vẫn thu gọn.
+- [ ] Mở rộng, đóng popup, mở lại → trạng thái mở rộng được giữ.
+- [ ] Hành vi tương tự ở chế độ side panel.
+
+## 16. Whitelist (gồm localhost & IP)
+
+- [ ] Thêm `youtube.com` qua text field Options → lưu; tab youtube.com được bảo vệ khỏi auto-unload.
+- [ ] Thêm `localhost` → tab `http://localhost:*` được bảo vệ.
+- [ ] Thêm `127.0.0.1` → tab `http://127.0.0.1:*` được bảo vệ.
+- [ ] Thêm `::1` (IPv6) → được bảo vệ.
+- [ ] Nhập sai (ví dụ `http://`) → input báo lỗi, không lưu.
+- [ ] Xóa entry → auto-unload kế tiếp có thể discard domain đó.
+- [ ] Context menu "Add to whitelist" trên tab localhost hoặc IP hoạt động trọn vẹn.
+
+## 17. Blacklist
+
+- [ ] Thêm domain ưu tiên thấp vào blacklist.
+- [ ] Tab thuộc domain đó discard ngay ở timer kế tiếp (bỏ qua delay).
+- [ ] Xóa entry → ngừng discard aggressive.
+
+## 18. Bảo vệ Pinned / Audio / Form
+
+- [ ] Tab ghim + bật `Protect pinned tabs` → không bao giờ discard qua auto-unload.
+- [ ] Tab phát YouTube + `Protect audio tabs` → không discard.
+- [ ] Tab có form chưa lưu (ví dụ Google Form điền dở) + `Protect form tabs` → không discard; dòng popup hiển thị badge "Form".
+- [ ] Tắt một protection → tab khớp trở lại đủ điều kiện.
+- [ ] **Force unload** (menu mỗi tab trong popup) override mọi protection.
+
+## 19. Optional Host Permissions + Form Injector
+- [ ] Cài mới: host permissions KHÔNG cấp mặc định.
+- [ ] Tắt rồi bật `Protect form tabs` → prompt cấp quyền hoặc banner phục hồi xuất hiện.
+- [ ] Cấp quyền → form-checker chỉ inject vào tab được truy cập; xác nhận qua badge popup và DevTools.
+- [ ] Thu hồi qua `chrome://extensions` → banner phục hồi tái xuất trong popup với CTA "Enable".
+- [ ] Bật `Discarded tab title prefix` → nếu chưa có quyền `scripting`/host, sẽ yêu cầu.
+
+## 20. Snooze
+
+- [ ] Snooze tab 30 phút → hiển thị badge "Snoozed"; auto-unload bỏ qua.
+- [ ] Snooze domain 1 giờ → mọi tab hiện tại và mới của domain được bảo vệ.
+- [ ] Hủy snooze → tab/domain trở lại đủ điều kiện.
+- [ ] Snooze giữ qua khởi động lại trình duyệt (trong cùng window).
+- [ ] Snooze tự hết hạn khi timer kết thúc.
+
+## 21. Cảnh báo trước khi suspend
+- [ ] Bật `Show suspend warning`; delay = 3000 ms.
+- [ ] Mở một tab và để nó đủ điều kiện auto-unload.
+- [ ] Toast xuất hiện trong trang 3 s trước khi discard.
+- [ ] Chuyển sang tab → hủy discard.
+- [ ] Bật audio/video, sửa form, hoặc snooze trong 3 s cũng hủy được.
+- [ ] Tắt setting → không có toast; tab discard im lặng.
+- [ ] Delay tùy chỉnh (ví dụ 5000 ms) được tôn trọng.
+
+## 22. Khôi phục thời điểm YouTube
+
+- [ ] Bật `Save YouTube timestamp`.
+- [ ] Phát video YouTube đến 1:00 rồi unload tab.
+- [ ] Reload tab đã discard → playback tiếp tục từ ≥ 0:55.
+- [ ] Sau > 7 ngày → cache hết hạn (kiểm tra thủ công: chỉnh `chrome.storage.sync`).
+
+## 23. Khôi phục vị trí cuộn
+
+- [ ] Bật `Restore scroll position`.
+- [ ] Cuộn nửa trang dài rồi để tab discard.
+- [ ] Mở lại tab → khôi phục trong khoảng ±50 px so với vị trí gốc.
+- [ ] Giới hạn 100 entry: discard 110 tab khác nhau và xác nhận entry cũ bị loại khỏi `tabrest_scroll_positions` (chrome.storage.local).
+
+## 24. Tab Groups
+
+- [ ] Tạo group có 3 tab.
+- [ ] Selector `Tab groups` trong popup hiển thị group với số tab.
+- [ ] "Unload this group" discard mọi tab trong group, giữ nguyên cấu trúc.
+- [ ] Tắt `Enable tab groups` → ẩn selector.
+
+## 25. Chỉ báo trực quan
+
+- [ ] Badge count = số tab discarded (toggle `Show badge count`).
+- [ ] Title prefix dùng glyph cấu hình (mặc định `💤`); glyph tùy chỉnh (≤ 4 ký tự) lưu và áp dụng sau prompt host permission.
+- [ ] Tắt prefix → title không thay đổi ở lần discard kế tiếp.
+- [ ] RAM % header popup cập nhật mỗi ~5 s.
+
+## 26. Tooltip ước lượng RAM
+- [ ] Hover stats RAM trong popup → tooltip giải thích ước lượng (ví dụ "~150 MB mỗi tab discarded").
+- [ ] Text tooltip có bản `vi`.
+- [ ] Tooltip biến mất khi rời chuột.
+
+## 27. Notifications
+
+- [ ] Bật `Notify on auto-unload`.
+- [ ] Trigger auto-unload → notification desktop với số tab + RAM tiết kiệm.
+- [ ] Notification tôn trọng OS focus-assist / Do Not Disturb.
+
+## 28. Thống kê
+
+- [ ] Sau khi unload vài tab, popup `Stats` hiển thị đúng tổng hôm nay + tổng thời gian.
+- [ ] Ước lượng "RAM saved" tăng.
+- [ ] "Member since" phản ánh ngày cài đặt.
+- [ ] "Reset stats" về 0 và xác nhận qua toast.
+
+## 29. Sessions
+
+- [ ] Lưu window hiện tại thành session "test-1" (popup → Sessions → đặt tên → Save).
+- [ ] Đóng mọi tab.
+- [ ] Restore "test-1" → mở lại đúng danh sách tab (URL khớp, thứ tự giữ nguyên).
+- [ ] Xóa "test-1" → entry biến mất.
+- [ ] 100+ session đã lưu phân trang hoặc cuộn không vỡ layout popup.
+
+## 30. Import / Export
+
+Cho từng loại: **whitelist**, **blacklist**, **sessions**:
+
+- [ ] Export → JSON copy vào clipboard với schema `version: 1`.
+- [ ] Xóa danh sách rồi Import lại JSON đã export → khôi phục đầy đủ, không trùng.
+- [ ] Import JSON có overlap → merge cộng dồn, dedup theo name (sessions) hoặc domain (whitelist/blacklist).
+- [ ] JSON sai cú pháp → toast lỗi, không thay đổi state.
+- [ ] Sai schema version → từ chối với thông báo rõ ràng.
+
+## 31. Side Panel
+
+- [ ] Options → Toolbar Action → bật `Open in side panel`.
+- [ ] Click icon toolbar → side panel mở (popup không mở).
+- [ ] Layout side panel responsive ở 360 px và 480 px.
+- [ ] Side panel giữ mở khi chuyển tab và window.
+- [ ] Tắt side panel → toolbar quay về popup.
+- [ ] Mọi tương tác (search, filter, snooze, save session, import/export) hoạt động trong side panel.
+
+## 32. Tự mở Changelog
+
+- [ ] Tăng version manifest từ `0.0.4` → `0.0.5` (patch). Reload extension → tab changelog KHÔNG tự mở.
+- [ ] Tăng `0.0.4` → `0.1.0` (minor) → trang changelog mở ở tab mới.
+- [ ] Tăng `0.1.0` → `1.0.0` (major) → changelog mở.
+- [ ] Khôi phục version; xóa `tabrest_lastVersion` trong `chrome.storage.local` để test lại.
+
+## 33. Theme (Dark / Light)
+
+- [ ] Toggle dark mode trong popup → áp dụng tức thì.
+- [ ] Mở Options ở window khác → đã ở dark mode (đồng bộ giữa các trang).
+- [ ] Toggle trong Options → popup theo theo.
+- [ ] Trang Onboarding & changelog match theme đã chọn.
+- [ ] Tôn trọng OS dark mode khi cài lần đầu.
+
+## 34. Bug Report / Báo cáo lỗi
+
+- [ ] Click "Report a bug" ở footer popup → modal mở với diagnostics tự điền (extension version, Chrome version, platform).
+- [ ] Submit → mở link issue GitHub có sẵn body.
+- [ ] Tắt `Send anonymous error reports` → lỗi service worker KHÔNG bị gửi (xác minh không có request mạng trong DevTools).
+- [ ] Bật → lỗi được thu thập qua `error-reporter.js` (test thủ công: throw lỗi giả).
+
+## 35. Onboarding
+
+- [ ] Cài mới → tab onboarding tự mở.
+- [ ] Đi qua các tính năng chính và link tới Options.
+- [ ] Theme khớp với preference người dùng.
+
+## 36. Bao phủ i18n
+
+- [ ] Đổi UI Chrome sang tiếng Việt.
+- [ ] Mọi chuỗi trong popup, options, onboarding, changelog, toast, notification, error message hiện tiếng Việt (không còn placeholder `__MSG_*__`, không fallback English ngoài ý đồ).
+- [ ] Số/ngày dùng định dạng đúng locale.
+
+## 37. Đồng bộ Settings
+
+- [ ] Đăng nhập Chrome với tài khoản có sync.
+- [ ] Sửa setting trên Profile A; trên Profile B (cùng tài khoản) xác nhận sync trong ~1 phút.
+- [ ] Sessions và whitelist truyền giữa các thiết bị (sessions lưu trong `chrome.storage.sync`).
+- [ ] Tab activity giữ riêng từng máy (`chrome.storage.local`).
+
+## 38. Độ bền Service Worker
+
+- [ ] Trong DevTools → Application → Service Workers → click "Stop" để kill worker.
+- [ ] Đợi > 30s. Mở 1 tab rồi để máy idle.
+- [ ] Worker tự thức qua `chrome.alarms`; auto-unload vẫn fire.
+- [ ] Phiên dài (≥ 4 giờ) không leak memory (`chrome://serviceworker-internals` cho thấy heap ổn định).
+
+## 39. Smoke test cross-browser (nhân Chromium)
+
+Spot-check trên:
+
+- [ ] Brave bản mới nhất
+- [ ] Edge bản mới nhất
+- [ ] Vivaldi bản mới nhất
+- [ ] Opera bản mới nhất
+
+Xác nhận popup load, unload thủ công OK, side panel render (nơi hỗ trợ), phím tắt phản hồi.
+
+## 40. Gỡ cài đặt / Dọn dẹp
+
+- [ ] Gỡ extension → mọi alarm bị xóa.
+- [ ] Chrome dọn storage entries (xác minh bằng cài lại sạch: stats reset, không còn snooze/sessions sót).
+- [ ] Không còn content script orphan ở các tab đã inject sau khi cài lại.
+
+---
+
+## Mẫu báo cáo lỗi
+
+Khi một mục check fail, mở issue với:
+
+- Section + ID mục checklist (ví dụ `§21 Cảnh báo trước khi suspend`).
+- Các bước reproduce.
+- Kết quả mong đợi vs thực tế.
+- Browser + OS + extension version.
+- Trích đoạn console DevTools service worker.
+- Screenshot hoặc video khi cần thiết.
+
+Repository: <https://github.com/lamngockhuong/tabrest/issues>


### PR DESCRIPTION
## Summary

- Add a detailed periodic self-test checklist covering every user-visible TabRest feature, in English and Vietnamese.
  - `docs/feature-test-checklist.md` — 40 sections, ~349 lines, ~60–90 min full pass.
  - `docs/vi/feature-test-checklist.md` — Vietnamese parity.
- Drop the now-redundant **"Phase 0X"** provenance labels from internal docs; the drowzy-parity sprints are shipped, so phase numbers no longer add information that "what the feature does" doesn't already convey.

## What's in the checklist

40 sections grouped by capability: pre-flight, auto-unload (timer / memory / per-tab heap / startup), min-tabs threshold, idle-only mode, skip when offline, Power Mode, manual controls, keyboard shortcuts, toolbar action, context menu, tab search, filter chips, persistent UI state, whitelist (incl. localhost / IP), blacklist, pinned/audio/form protection, optional host permissions + form injector recovery banner, snooze, suspend warning toast, YouTube timestamp, scroll restore, tab groups, visual indicators, memory tooltip, notifications, stats, sessions, import/export, side panel, gated changelog auto-open, theme sync, bug report / error reporting, onboarding, i18n, settings sync, service worker resilience, cross-browser smoke, uninstall cleanup. Includes a status legend (`[ ]` / `[x]` / `[!]` / `[~]`) and an issue-reporting template.

## Files touched

- **Added:** `docs/feature-test-checklist.md`, `docs/vi/feature-test-checklist.md`
- **Modified (Phase label cleanup):** `docs/code-standards.md`, `docs/codebase-summary.md`, `docs/project-overview-pdr.md`, `docs/project-roadmap.md`, `docs/system-architecture.md`

`### Phase 1/2/3 (Q2/Q3/Q4 2026)` headings in the roadmap are intentionally kept — those are forward-looking project phases, not the shipped sprint phases.

## Test plan

- [x] Both checklist files render cleanly (verified via Read).
- [x] No remaining `Phase 0X` references in internal docs (Grep clean).
- [ ] Reviewer to walk one section end-to-end against the loaded extension and confirm steps match real UX.