### PR TITLE
docs: add community files and Vietnamese README

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+github: lamngockhuong
+buy_me_a_coffee: lamngockhuong
+custom:
+  - https://me.momo.vn/khuong

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,61 @@
+---
+name: Bug Report
+about: Report a bug to help us improve
+title: "[Bug] "
+labels: bug
+assignees: ""
+---
+
+## Description
+
+<!-- Clear description of the bug -->
+
+## Steps to Reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. Wait for '...'
+4. See error
+
+## Expected Behavior
+
+<!-- What you expected to happen -->
+
+## Actual Behavior
+
+<!-- What actually happened -->
+
+## Screenshots
+
+<!-- If applicable, add screenshots -->
+
+## Environment
+
+- **Browser**: Chrome [version]
+- **Extension Version**: [e.g. 0.0.4]
+- **OS**: [e.g. Windows 11, macOS 15]
+
+## Affected Feature
+
+- [ ] Auto-unload (timer)
+- [ ] Memory threshold / per-tab memory limit
+- [ ] Manual unload (current/left/right/other)
+- [ ] Whitelist / Snooze
+- [ ] Sessions / Import-Export
+- [ ] Side panel mode
+- [ ] Tab search / duplicates
+- [ ] YouTube timestamp / scroll restore
+- [ ] Notifications / statistics
+- [ ] Other: \_\_\_
+
+## Service Worker Errors
+
+<!-- Open chrome://extensions → TabRest → "Inspect views: service worker" → Console tab, paste any errors -->
+
+```
+
+```
+
+## Additional Context
+
+<!-- Any other context about the problem -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discussions
+    url: https://github.com/lamngockhuong/tabrest/discussions
+    about: Ask questions and share ideas

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,31 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+title: "[Feature] "
+labels: enhancement
+assignees: ""
+---
+
+## Problem
+
+<!-- What problem does this feature solve? -->
+
+## Proposed Solution
+
+<!-- How should the feature work? -->
+
+## Alternatives Considered
+
+<!-- Other approaches you've considered -->
+
+## Use Case
+
+<!-- Describe the scenario where this feature would be useful -->
+
+## Mockups
+
+<!-- If applicable, add mockups or sketches -->
+
+## Additional Context
+
+<!-- Any other context or references -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+## Summary
+
+<!-- Brief description of the changes -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Enhancement
+- [ ] Refactoring
+- [ ] Documentation
+- [ ] CI/Build
+
+## Changes
+
+-
+
+## Testing
+
+- [ ] `pnpm lint` passes
+- [ ] `pnpm test` passes
+- [ ] `pnpm run validate:manifest` passes
+- [ ] Tested as unpacked extension in Chrome
+
+## Screenshots
+
+<!-- If UI changes, add before/after screenshots -->
+
+## Checklist
+
+- [ ] Code follows project conventions (`docs/code-standards.md`)
+- [ ] No service worker errors (`chrome://extensions` → Inspect service worker)
+- [ ] Settings persist correctly across reloads
+- [ ] No secrets or API keys committed

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,31 @@
+# Code of Conduct
+
+## Our Pledge
+
+We pledge to make participation in our project a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+**Positive behavior includes:**
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints
+- Accepting constructive criticism gracefully
+- Focusing on what is best for the community
+
+**Unacceptable behavior includes:**
+
+- Trolling, insulting comments, and personal attacks
+- Harassment in any form
+- Publishing others' private information without consent
+- Other conduct which could be considered inappropriate
+
+## Enforcement
+
+Project maintainers are responsible for clarifying standards and are expected to take appropriate action in response to unacceptable behavior.
+
+Instances of unacceptable behavior may be reported by opening an issue or contacting the maintainer directly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,101 @@
+# Contributing to TabRest
+
+Thank you for your interest in contributing!
+
+## Getting Started
+
+1. Fork the repository
+2. Clone your fork:
+
+   ```bash
+   git clone https://github.com/<your-username>/tabrest.git
+   cd tabrest
+   ```
+
+3. Install dependencies:
+
+   ```bash
+   pnpm install
+   ```
+
+4. Create a branch:
+
+   ```bash
+   git checkout -b feat/your-feature
+   ```
+
+## Development
+
+```bash
+pnpm lint              # Check code style
+pnpm lint:fix          # Auto-fix issues
+pnpm test              # Run tests
+pnpm run validate:manifest  # Validate manifest.json
+pnpm run ci            # Full CI (validate + lint + test)
+```
+
+### Loading the Extension
+
+1. Open `chrome://extensions/`
+2. Enable **Developer mode**
+3. Click **Load unpacked** and select the project root
+4. View service worker logs: TabRest → "Inspect views: service worker"
+
+## Project Structure
+
+```text
+src/
+├── background/   # Service worker modules (orchestration, unload logic, LRU, memory)
+├── content/      # Content scripts (form checker, YouTube tracker)
+├── popup/        # Popup / side panel UI
+├── options/      # Settings page
+├── pages/        # Onboarding, changelog
+└── shared/       # Constants, storage wrapper, utilities
+```
+
+See `docs/system-architecture.md` and `CLAUDE.md` for module dependency flow.
+
+## Adding a New Feature
+
+1. Add default to `SETTINGS_DEFAULTS` in `src/shared/constants.js`
+2. Implement logic in the appropriate `src/background/*` module
+3. Add UI toggle in `src/options/options.html` (and popup if user-facing)
+4. Wire up the storage key in the corresponding JS file
+5. Add i18n strings to `_locales/en/messages.json` and `_locales/vi/messages.json`
+6. Update `docs/` if it changes architecture or user-facing behavior
+
+## Code Style
+
+- Vanilla JavaScript (ES Modules) — no build step for extension code
+- Keep files under 200 lines; split by concern
+- Follow existing patterns in the codebase
+- Run `pnpm lint` before committing
+- See `docs/code-standards.md` for details
+
+## Commit Messages
+
+Use [conventional commits](https://www.conventionalcommits.org/):
+
+- `feat:` new feature
+- `fix:` bug fix
+- `docs:` documentation changes
+- `refactor:` code refactoring
+- `test:` adding or updating tests
+- `chore:` maintenance tasks
+
+## Pull Requests
+
+1. Ensure `pnpm run ci` passes
+2. Test the extension as unpacked in Chrome
+3. Fill out the PR template
+4. Keep PRs focused on a single change
+
+## Reporting Issues
+
+- Use the **Bug Report** template for bugs
+- Use the **Feature Request** template for suggestions
+- Include browser version, extension version, and steps to reproduce
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+🇬🇧 **English** | 🇻🇳 [Tiếng Việt](README.vi.md)
+
 <p align="center">
   <img src="icons/icon-128.png" alt="TabRest Logo" width="128" height="128">
 </p>
@@ -120,6 +122,19 @@ Chrome Web Store promotional images are in `assets/` as SVG sources.
 - No external servers
 - All settings stored locally
 - See [Privacy Policy](docs/privacy-policy.md)
+
+## Sponsor
+
+If you find this extension useful, consider supporting its development:
+
+[![GitHub Sponsors](https://img.shields.io/badge/GitHub_Sponsors-Support-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/lamngockhuong)
+[![Buy Me A Coffee](https://img.shields.io/badge/Buy_Me_A_Coffee-Support-FFDD00?logo=buymeacoffee&logoColor=black)](https://buymeacoffee.com/lamngockhuong)
+[![MoMo](https://img.shields.io/badge/MoMo-Support-ae2070)](https://me.momo.vn/khuong)
+
+## Other Projects
+
+- [GitHub Flex](https://github.com/lamngockhuong/github-flex) - Cross-browser extension that enhances GitHub's interface with productivity features
+- [Termote](https://github.com/lamngockhuong/termote) - Remote control CLI tools (Claude Code, GitHub Copilot, any terminal) from mobile/desktop via PWA
 
 ## License
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -1,0 +1,141 @@
+🇬🇧 [English](README.md) | 🇻🇳 **Tiếng Việt**
+
+<p align="center">
+  <img src="icons/icon-128.png" alt="TabRest Logo" width="128" height="128">
+</p>
+
+<h1 align="center">TabRest</h1>
+
+<p align="center">
+  Cho tab nghỉ ngơi, giải phóng bộ nhớ - tiện ích Chrome tự động unload các tab không hoạt động.
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Manifest-V3-blue?logo=googlechrome" alt="Manifest V3">
+  <img src="https://img.shields.io/github/actions/workflow/status/lamngockhuong/tabrest/ci.yml?branch=main&logo=github" alt="CI Status">
+  <img src="https://img.shields.io/badge/code_style-biome-60a5fa?logo=biome" alt="Code Style: Biome">
+  <img src="https://img.shields.io/badge/JavaScript-ES_Modules-f7df1e?logo=javascript&logoColor=black" alt="JavaScript ES Modules">
+  <img src="https://img.shields.io/github/license/lamngockhuong/tabrest" alt="License">
+</p>
+
+## Tính năng
+
+- **Tự động unload tab không hoạt động** - Hẹn giờ tuỳ chỉnh (15 phút đến 4 giờ)
+- **Ngưỡng bộ nhớ** - Unload khi RAM vượt 60-90%
+- **Giới hạn bộ nhớ mỗi tab** - Unload tab dùng >100MB-1GB JS heap
+- **Unload khi khởi động** - Giải phóng bộ nhớ khi mở trình duyệt
+- **Điều khiển thủ công** - Unload tab hiện tại/trái/phải/khác
+- **Đóng tab trùng lặp** - Một cú nhấp dedup trong cửa sổ hiện tại
+- **Tìm kiếm tab** - Lọc danh sách tab theo tiêu đề hoặc URL
+- **Nhóm tab** - Unload toàn bộ nhóm tab
+- **Chế độ side panel** - Mở TabRest trong side panel của Chrome (tuỳ chọn)
+- **Snooze tab/site** - Tạm thời bảo vệ tab hoặc domain (30 phút - 2 giờ)
+- **Cảnh báo trước khi unload** - Toast 3 giây cảnh báo trên trang trước khi auto-discard
+- **Chỉ báo trực quan** - Tiền tố tuỳ chỉnh (💤) trên tiêu đề tab đã unload
+- **Whitelist** - Bảo vệ site khỏi auto-unload (hỗ trợ localhost & IP)
+- **Import/Export** - Sao lưu whitelist, blacklist và session ra JSON
+- **Session** - Lưu và khôi phục bộ tab
+- **Khôi phục cuộn trang** - Khôi phục vị trí cuộn khi tab tải lại
+- **Timestamp YouTube** - Tiếp tục video tại vị trí cuối sau khi tải lại
+- **Bỏ qua khi offline** - Không discard tab khi mất mạng
+- **Chỉ unload khi nhàn rỗi** - Chỉ auto-unload khi máy tính idle
+- **Power Mode** - Chế độ tiết kiệm pin, bình thường, hoặc hiệu năng cao
+- **Thông báo auto-unload** - Nhận thông báo khi tab được unload
+- **Tooltip bộ nhớ** - Hover thống kê để xem ước tính RAM tiết kiệm trên mỗi tab
+- **Tự mở changelog** - Mở release notes khi cập nhật minor/major
+- **Host permissions tuỳ chọn** - Bảo vệ form chỉ yêu cầu quyền khi bật
+- **Hiển thị RAM** - Phần trăm RAM trực tiếp trên popup
+- **Thống kê** - Theo dõi số tab đã unload và bộ nhớ đã tiết kiệm
+- **Đa ngôn ngữ** - Hỗ trợ tiếng Anh và tiếng Việt
+
+## Phím tắt
+
+| Phím tắt      | Hành động              |
+| ------------- | ---------------------- |
+| `Alt+Shift+D` | Unload tab hiện tại    |
+| `Alt+Shift+O` | Unload các tab khác    |
+| `Alt+Shift+→` | Unload tab bên phải    |
+| `Alt+Shift+←` | Unload tab bên trái    |
+
+## Cài đặt
+
+### Từ mã nguồn
+
+1. Clone repository này
+2. Mở `chrome://extensions` trong Chrome
+3. Bật "Chế độ nhà phát triển" (góc trên bên phải)
+4. Nhấp "Tải tiện ích đã giải nén"
+5. Chọn thư mục dự án
+
+### Từ Chrome Web Store
+
+Sắp ra mắt.
+
+## Cách hoạt động
+
+TabRest sử dụng API native `chrome.tabs.discard()` của Chrome để unload tab. Tab đã discard:
+
+- Vẫn hiển thị trên thanh tab
+- Giữ nguyên vị trí cuộn và dữ liệu form
+- Tải lại ngay lập tức khi nhấp vào
+- Giải phóng bộ nhớ khi không hoạt động
+
+## Cấu trúc dự án
+
+```text
+tabrest/
+├── manifest.json           # Cấu hình tiện ích (MV3)
+├── _locales/               # Bản dịch i18n (en, vi)
+├── src/
+│   ├── background/         # Module service worker
+│   ├── content/            # Form checker, YouTube tracker
+│   ├── popup/              # UI popup / side panel
+│   ├── options/            # Trang cài đặt
+│   ├── pages/              # Onboarding, changelog
+│   └── shared/             # Tiện ích dùng chung
+├── icons/                  # Biểu tượng tiện ích
+├── website/                # Trang docs Astro (tabrest.ohnice.app)
+└── docs/                   # Tài liệu dự án
+```
+
+## Phát triển
+
+```bash
+pnpm install          # Cài dependencies
+pnpm run lint         # Kiểm tra code với Biome
+pnpm run lint:fix     # Tự động sửa lỗi lint
+pnpm run format       # Format code
+pnpm run ci           # Chạy CI đầy đủ (validate + lint)
+```
+
+## Tài nguyên quảng bá
+
+Hình ảnh quảng bá Chrome Web Store nằm trong `assets/` dưới dạng nguồn SVG.
+
+```bash
+./scripts/generate-promo-images.sh   # Tạo file PNG
+```
+
+## Quyền riêng tư
+
+- Không thu thập dữ liệu
+- Không có server bên ngoài
+- Tất cả cài đặt lưu cục bộ
+- Xem [Chính sách quyền riêng tư](docs/privacy-policy.md)
+
+## Tài trợ
+
+Nếu bạn thấy tiện ích này hữu ích, hãy cân nhắc hỗ trợ phát triển:
+
+[![GitHub Sponsors](https://img.shields.io/badge/GitHub_Sponsors-Hỗ_trợ-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/lamngockhuong)
+[![Buy Me A Coffee](https://img.shields.io/badge/Buy_Me_A_Coffee-Hỗ_trợ-FFDD00?logo=buymeacoffee&logoColor=black)](https://buymeacoffee.com/lamngockhuong)
+[![MoMo](https://img.shields.io/badge/MoMo-Hỗ_trợ-ae2070)](https://me.momo.vn/khuong)
+
+## Dự án khác
+
+- [GitHub Flex](https://github.com/lamngockhuong/github-flex) - Tiện ích đa trình duyệt nâng cấp giao diện GitHub với các tính năng tăng năng suất
+- [Termote](https://github.com/lamngockhuong/termote) - Điều khiển CLI từ xa (Claude Code, GitHub Copilot, bất kỳ terminal nào) từ di động/máy tính qua PWA
+
+## Giấy phép
+
+MIT

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| Latest  | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it responsibly:
+
+1. **Do not** open a public issue
+2. Email the maintainer or use [GitHub Security Advisories](https://github.com/lamngockhuong/tabrest/security/advisories/new)
+3. Include steps to reproduce the vulnerability
+4. Allow reasonable time for a fix before public disclosure
+
+## Scope
+
+This extension runs locally in Chrome and:
+
+- Does not collect or transmit user data
+- Stores settings via `chrome.storage.sync` and tab activity via `chrome.storage.local`
+- Does not make external network requests
+- Requests host permissions only when the user enables features that need them (e.g. discarded-tab title prefix, form protection)
+- Uses Manifest V3 with no remote code execution
+
+## Response
+
+- Acknowledgment within 48 hours
+- Fix timeline communicated within 7 days
+- Credit given in release notes (unless anonymity requested)


### PR DESCRIPTION
## Summary

- Add FUNDING.yml (GitHub Sponsors, Buy Me A Coffee, MoMo)
- Add issue templates (bug, feature, config) and PR template
- Add SECURITY.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md
- Add Sponsor and Other Projects sections to README
- Add Vietnamese README (README.vi.md) with language switcher

## Type of Change

- [x] Documentation

## Changes

- `.github/FUNDING.yml` — funding links
- `.github/ISSUE_TEMPLATE/{bug_report,feature_request,config}.{md,yml}` — issue templates with TabRest-specific feature checklist
- `.github/pull_request_template.md` — PR checklist
- `SECURITY.md` — vulnerability disclosure policy and scope
- `CONTRIBUTING.md` — dev setup, project structure, conventional commits
- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1
- `README.md` — language switcher + Sponsor + Other Projects sections
- `README.vi.md` — full Vietnamese translation

## Testing

- [x] Markdown renders correctly on GitHub
- [x] Language switcher links resolve

## Checklist

- [x] No secrets or API keys committed