### PR TITLE
fix(background): whitelist wins over blacklist precedence

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -293,6 +293,14 @@
     "message": "Domain already exists",
     "description": "Error message"
   },
+  "domainConflict": {
+    "message": "$1 is already in $2 — remove it from there first",
+    "description": "Error when adding a domain that exists in the opposite list",
+    "placeholders": {
+      "1": { "content": "$1" },
+      "2": { "content": "$2" }
+    }
+  },
   "domainAdded": {
     "message": "Domain added",
     "description": "Status message"

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -217,6 +217,13 @@
   "domainExists": {
     "message": "Tên miền đã tồn tại"
   },
+  "domainConflict": {
+    "message": "$1 đã có trong $2 — xóa khỏi đó trước",
+    "placeholders": {
+      "1": { "content": "$1" },
+      "2": { "content": "$2" }
+    }
+  },
   "domainAdded": {
     "message": "Đã thêm tên miền"
   },

--- a/docs/feature-test-checklist.md
+++ b/docs/feature-test-checklist.md
@@ -151,12 +151,15 @@ Configurable at `chrome://extensions/shortcuts`.
 - [ ] Invalid entry (e.g., `http://`) → input shows error, not saved.
 - [ ] Remove an entry → next auto-unload may discard that domain.
 - [ ] Context menu "Add to whitelist" on a localhost or IP tab works end-to-end.
+- [ ] Add a domain that already exists in blacklist → toast shows conflict message, not added.
 
 ## 17. Blacklist
 
 - [ ] Add a low-priority domain to blacklist.
 - [ ] Tabs on that domain discard on the very next timer tick (ignoring delay).
 - [ ] Removing entry stops aggressive discard.
+- [ ] Add a domain that already exists in whitelist → toast shows conflict message, not added.
+- [ ] Domain in both lists (e.g., via legacy state) → whitelist wins, tab is protected.
 
 ## 18. Pinned / Audio / Form Protection
 
@@ -253,6 +256,7 @@ For each of: **whitelist**, **blacklist**, **sessions**:
 - [ ] Export → JSON copied to clipboard with `version: 1` schema.
 - [ ] Empty the list, then Import the previously exported JSON → list restored, no duplicates.
 - [ ] Import a JSON with overlap → additive merge, dedup by name (sessions) or domain (whitelist/blacklist).
+- [ ] Import whitelist/blacklist with entries already in opposite list → those entries skipped (counted in skipped), no conflict created.
 - [ ] Malformed JSON → error toast, no state change.
 - [ ] Wrong schema version → rejected with clear message.
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -110,6 +110,7 @@ service-worker.js
 3. For each tab in tabActivity map:
        │
        ├── Verify tab exists, not active, not discarded
+       ├── Check whitelist (skip — wins over blacklist)
        ├── Check if blacklisted (immediate unload)
        ├── Check if exceeded inactivity threshold
        ├── Check if snoozed

--- a/docs/vi/feature-test-checklist.md
+++ b/docs/vi/feature-test-checklist.md
@@ -151,12 +151,15 @@ Cấu hình tại `chrome://extensions/shortcuts`.
 - [ ] Nhập sai (ví dụ `http://`) → input báo lỗi, không lưu.
 - [ ] Xóa entry → auto-unload kế tiếp có thể discard domain đó.
 - [ ] Context menu "Add to whitelist" trên tab localhost hoặc IP hoạt động trọn vẹn.
+- [ ] Thêm domain đã có trong blacklist → toast báo conflict, không thêm.
 
 ## 17. Blacklist
 
 - [ ] Thêm domain ưu tiên thấp vào blacklist.
 - [ ] Tab thuộc domain đó discard ngay ở timer kế tiếp (bỏ qua delay).
 - [ ] Xóa entry → ngừng discard aggressive.
+- [ ] Thêm domain đã có trong whitelist → toast báo conflict, không thêm.
+- [ ] Domain xuất hiện ở cả 2 list (state cũ) → whitelist thắng, tab được bảo vệ.
 
 ## 18. Bảo vệ Pinned / Audio / Form
 
@@ -253,6 +256,7 @@ Cho từng loại: **whitelist**, **blacklist**, **sessions**:
 - [ ] Export → JSON copy vào clipboard với schema `version: 1`.
 - [ ] Xóa danh sách rồi Import lại JSON đã export → khôi phục đầy đủ, không trùng.
 - [ ] Import JSON có overlap → merge cộng dồn, dedup theo name (sessions) hoặc domain (whitelist/blacklist).
+- [ ] Import whitelist/blacklist có entry trùng list đối lập → entry đó bị skip (đếm vào skipped), không tạo conflict.
 - [ ] JSON sai cú pháp → toast lỗi, không thay đổi state.
 - [ ] Sai schema version → từ chối với thông báo rõ ràng.
 

--- a/src/background/tab-tracker.js
+++ b/src/background/tab-tracker.js
@@ -2,7 +2,7 @@ import { ALARM_NAMES, POWER_MODE_CONFIG } from "../shared/constants.js";
 import { getSettings, getTabActivity, saveTabActivity } from "../shared/storage.js";
 import { notifyAutoUnload } from "../shared/utils.js";
 import { getSnoozeData, isTabSnoozed } from "./snooze-manager.js";
-import { discardTab, isUrlBlacklisted } from "./unload-manager.js";
+import { discardTab, isUrlBlacklisted, isUrlWhitelisted } from "./unload-manager.js";
 
 // In-memory cache of tab activity: { tabId: lastActiveTimestamp }
 let tabActivity = {};
@@ -102,6 +102,9 @@ export async function checkAndUnloadInactiveTabs() {
     // Verify tab still exists and is eligible (O(1) lookup)
     const tab = tabMap.get(tabId);
     if (!tab || tab.active || tab.discarded) continue;
+
+    // Whitelist wins over blacklist — skip entirely (matches discardTab gate)
+    if (isUrlWhitelisted(tab.url, settings)) continue;
 
     // Blacklisted tabs: unload immediately regardless of activity time
     const blacklisted = isUrlBlacklisted(tab.url, settings);

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -12,6 +12,8 @@ import { getSettings, saveSettings } from "../shared/storage.js";
 import { initTheme, onThemeChange, toggleTheme, updateThemeIcon } from "../shared/theme.js";
 import { formatBytes, getBrowserInfo, isValidDomainOrIp } from "../shared/utils.js";
 
+const OPPOSITE_LIST = { whitelist: "blacklist", blacklist: "whitelist" };
+
 const elements = {
   themeToggle: document.getElementById("theme-toggle"),
   themeIcon: document.getElementById("theme-icon"),
@@ -359,6 +361,12 @@ async function addDomainToList(inputEl, listKey, renderFn) {
     return;
   }
 
+  const oppositeKey = OPPOSITE_LIST[listKey];
+  if (currentSettings[oppositeKey]?.includes(domain)) {
+    showStatus(t("domainConflict", [domain, t(oppositeKey)]));
+    return;
+  }
+
   currentSettings[listKey].push(domain);
   await saveSettings(currentSettings);
   inputEl.value = "";
@@ -387,13 +395,18 @@ async function importList(listKey, renderFn) {
     return;
   }
   const entries = Array.isArray(result.data.entries) ? result.data.entries : [];
+  const oppositeKey = OPPOSITE_LIST[listKey];
   let added = 0;
   let skipped = 0;
   for (const raw of entries) {
     const entry = String(raw || "")
       .trim()
       .toLowerCase();
-    if (!isValidDomainOrIp(entry) || currentSettings[listKey].includes(entry)) {
+    if (
+      !isValidDomainOrIp(entry) ||
+      currentSettings[listKey].includes(entry) ||
+      currentSettings[oppositeKey]?.includes(entry)
+    ) {
       skipped++;
       continue;
     }

--- a/tests/background/tab-tracker.test.js
+++ b/tests/background/tab-tracker.test.js
@@ -19,12 +19,17 @@ vi.mock("../../src/background/snooze-manager.js", () => ({
 vi.mock("../../src/background/unload-manager.js", () => ({
   discardTab: vi.fn(),
   isUrlBlacklisted: vi.fn(),
+  isUrlWhitelisted: vi.fn(),
 }));
 
 import { getSettings, getTabActivity, saveTabActivity } from "../../src/shared/storage.js";
 import { notifyAutoUnload } from "../../src/shared/utils.js";
 import { getSnoozeData, isTabSnoozed } from "../../src/background/snooze-manager.js";
-import { discardTab, isUrlBlacklisted } from "../../src/background/unload-manager.js";
+import {
+  discardTab,
+  isUrlBlacklisted,
+  isUrlWhitelisted,
+} from "../../src/background/unload-manager.js";
 
 const importTracker = () => import("../../src/background/tab-tracker.js");
 
@@ -41,6 +46,7 @@ const baseSettings = {
 describe("tab-tracker", () => {
   beforeEach(() => {
     vi.resetModules();
+    isUrlWhitelisted.mockReturnValue(false);
     Object.defineProperty(navigator, "onLine", {
       value: true,
       writable: true,
@@ -230,6 +236,21 @@ describe("tab-tracker", () => {
 
       const { checkAndUnloadInactiveTabs } = await setupTracker({ 1: recentTime });
       expect(await checkAndUnloadInactiveTabs()).toBe(1);
+    });
+
+    it("whitelist wins over blacklist — never unloads", async () => {
+      const oldTime = Date.now() - 60 * 60 * 1000;
+      chrome.tabs.query.mockResolvedValue([
+        { id: 1, url: "https://both.com", active: false, discarded: false, title: "X" },
+      ]);
+      isUrlWhitelisted.mockReturnValue(true);
+      isUrlBlacklisted.mockReturnValue(true);
+      isTabSnoozed.mockResolvedValue(false);
+      getSnoozeData.mockResolvedValue({ tabs: {}, domains: {} });
+
+      const { checkAndUnloadInactiveTabs } = await setupTracker({ 1: oldTime });
+      expect(await checkAndUnloadInactiveTabs()).toBe(0);
+      expect(discardTab).not.toHaveBeenCalled();
     });
 
     it("skips tabs that are active or already discarded", async () => {


### PR DESCRIPTION
## Summary

- Resolve ambiguous behavior when a domain appears in both whitelist and blacklist — whitelist always wins (matches user expectation set by tools like uBlock Origin and Auto Tab Discard, and avoids accidental data loss on protected tabs)
- Short-circuit whitelist check in `tab-tracker.js` before the blacklist bypass so we skip the redundant `discardTab` call (whitelist re-checked in `passesStaticGates` is kept as defense-in-depth for other callers)
- Block conflicting entries at the source: both manual add and bulk import in Options reject domains that already exist in the opposite list, so users can't create ambiguous state from the UI

## Changes

- `src/background/tab-tracker.js` — early-return guard for whitelisted tabs in `checkAndUnloadInactiveTabs`
- `src/options/options.js` — `addDomainToList` shows conflict toast; `importList` skips conflicting entries (counted in skipped); module-level `OPPOSITE_LIST` lookup
- `_locales/en|vi/messages.json` — new `domainConflict` key with `$1` (domain) + `$2` (opposite list name) placeholders
- `docs/system-architecture.md` — add whitelist check in tab-tracker decision flow diagram
- `docs/feature-test-checklist.md` + vi version — add manual conflict + import-conflict + dual-list-precedence checks
- `tests/background/tab-tracker.test.js` — mock `isUrlWhitelisted`, add "whitelist wins over blacklist" test

## Test plan

- [x] Run `pnpm test --run` — 289/289 pass
- [x] Load extension in Chrome → add `example.com` to whitelist, then try add to blacklist → toast `example.com is already in Whitelist — remove it from there first`, not added
- [x] Same flow reversed (blacklist first, then whitelist) → same conflict toast
- [x] Export blacklist with overlap entry, import into whitelist → entry skipped (counted in skipped)
- [x] Force a dual-list state (legacy storage), open inactive tab → tab stays protected, never discarded