### PR TITLE
feat(settings): add more granular timer and RAM threshold options

### DIFF
--- a/docs/chrome-web-store-listing.md
+++ b/docs/chrome-web-store-listing.md
@@ -30,8 +30,8 @@ TabRest automatically unloads inactive browser tabs to free up memory and keep y
 ✨ KEY FEATURES:
 
 📌 Smart Auto-Unload
-• Configurable inactivity timer (15 minutes to 4 hours)
-• Memory threshold trigger (60-90% RAM usage)
+• Configurable inactivity timer (5 minutes to 4 hours)
+• Memory threshold trigger (60-95% RAM usage)
 • Per-tab memory limit (unload tabs using >100MB-1GB JS heap)
 • Startup unload option to free memory when browser opens
 • Skip when offline - don't unload tabs when network unavailable

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -40,6 +40,8 @@
         <label for="timer" data-i18n="unloadInactiveAfter">Unload inactive tabs after:</label>
         <select id="timer">
           <option value="0" data-i18n="disabled">Disabled</option>
+          <option value="5">5 minutes</option>
+          <option value="10">10 minutes</option>
           <option value="15">15 minutes</option>
           <option value="30">30 minutes</option>
           <option value="60">1 hour</option>
@@ -92,9 +94,13 @@
         <select id="threshold">
           <option value="0" data-i18n="disabled">Disabled</option>
           <option value="60">60%</option>
+          <option value="65">65%</option>
           <option value="70">70%</option>
+          <option value="75">75%</option>
           <option value="80">80%</option>
+          <option value="85">85%</option>
           <option value="90">90%</option>
+          <option value="95">95%</option>
         </select>
       </div>
       <div class="setting">

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -143,19 +143,27 @@
             <label data-i18n="autoUnloadAfter">Auto-unload after</label>
             <select id="timer-select" class="select">
               <option value="0" data-i18n="disabled">Disabled</option>
+              <option value="5">5 minutes</option>
+              <option value="10">10 minutes</option>
               <option value="15">15 minutes</option>
               <option value="30">30 minutes</option>
               <option value="60">1 hour</option>
               <option value="120">2 hours</option>
+              <option value="240">4 hours</option>
             </select>
           </div>
           <div class="setting-row">
             <label data-i18n="ramThreshold">RAM threshold</label>
             <select id="threshold-select" class="select">
               <option value="0" data-i18n="disabled">Disabled</option>
+              <option value="60">60%</option>
+              <option value="65">65%</option>
               <option value="70">70%</option>
+              <option value="75">75%</option>
               <option value="80">80%</option>
+              <option value="85">85%</option>
               <option value="90">90%</option>
+              <option value="95">95%</option>
             </select>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Auto-unload timer: added **5 minutes** and **10 minutes** options. Popup now also exposes **4 hours** to match the options page.
- RAM threshold: expanded with 65/75/85/95% increments. Floor kept at **60%** (50% would fire constantly on typical machines whose idle RAM sits 50-70%).

## Test plan
- [ ] Open Options page → "Unload inactive tabs after" shows 5/10 min in addition to existing values
- [ ] Open Options page → "Unload tabs when RAM exceeds" shows 60/65/70/75/80/85/90/95%
- [ ] Open popup Quick Settings → both selects expose the same option set
- [ ] Pick a new value (e.g. 5 min, 65%) → reload extension → setting persists
- [ ] `pnpm test` passes (289 tests)