### PR TITLE
fix(popup): correct protection badges for pinned/audio/form tabs

### DIFF
--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -43,13 +43,13 @@ tabrest/
 | `snooze-manager.js`  | 164 | Temporary tab/domain protection                  |
 | `session-manager.js` | 209 | Save/restore tab sessions, import with merge & dedup |
 | `stats-collector.js` | 99  | Usage statistics tracking                        |
-| `form-injector.js`   | 24  | On-demand form-checker injection (lazy-loaded)   |
+| `form-injector.js`   | 24  | Form-checker injection (eager on page load + lazy on demand) |
 
 ### Content Scripts
 
 | File                 | LOC | Purpose                                     |
 | -------------------- | --- | ------------------------------------------- |
-| `form-checker.js`    | 201 | Detect unsaved forms, report JS heap memory (lazy-injected) |
+| `form-checker.js`    | 201 | Detect unsaved forms (global flag on first input), report JS heap memory |
 | `youtube-tracker.js` | 132 | Save/restore YouTube playback position      |
 
 ### UI Components

--- a/docs/feature-test-checklist.md
+++ b/docs/feature-test-checklist.md
@@ -164,15 +164,18 @@ Configurable at `chrome://extensions/shortcuts`.
 ## 18. Pinned / Audio / Form Protection
 
 - [ ] Pinned tab + `Protect pinned tabs` ON → never discards via auto-unload.
+- [ ] Pinned tab + `Include pinned tabs` ON (i.e., pinned tabs eligible) → popup row still shows "pin" badge (intrinsic), and the protected filter chip count includes it.
 - [ ] Tab playing YouTube audio + `Protect audio tabs` ON → never discards.
 - [ ] Tab with unsaved form (e.g., partially filled Google Form) + `Protect form tabs` ON → not discarded; popup row shows "Form" badge.
+- [ ] Tab with unsaved form on a React/contenteditable editor (e.g., GitHub issue body) → after typing, popup row shows "Form" badge (eager-injection captures keystrokes).
+- [ ] Whitelisted tab that is also pinned/audio/form → popup shows the more specific badge (pin/audio/form), not "safe" — whitelist is the lowest-priority reason.
 - [ ] Disable a protection → matching tabs become eligible.
 - [ ] **Force unload** (per-tab menu in popup) overrides all protections.
 
 ## 19. Optional Host Permissions + Form Injector
 - [ ] On a fresh install, host permissions NOT granted by default.
 - [ ] Toggle `Protect form tabs` OFF then ON → permission prompt or recovery banner appears.
-- [ ] Grant permission → form-checker injects only on tabs accessed; verify in popup row badges and DevTools.
+- [ ] Grant permission → form-checker injects eagerly on every page load (and lazily for already-open tabs on first check); verify via popup row badges and `window.__tabrestFormCheckLoaded` in DevTools.
 - [ ] Revoke via `chrome://extensions` → recovery banner reappears in popup with "Enable" CTA.
 - [ ] Toggle `Discarded tab title prefix` ON → if `scripting`/host perms not granted, requests them.
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -89,7 +89,7 @@ service-worker.js
 | `snooze-manager`  | Manage temporary protections                    | storage                                    |
 | `session-manager` | Save/restore tab sessions                       | storage                                    |
 | `stats-collector` | Track unload statistics                         | storage                                    |
-| `form-injector`   | Lazy-inject form-checker on demand              | permissions                                |
+| `form-injector`   | Inject form-checker (eager on page load + lazy) | permissions                                |
 
 ## Data Flow
 
@@ -297,17 +297,18 @@ service-worker.js
 
 1. Manifest declares `optional_host_permissions: ["http://*/*", "https://*/*"]`
 2. `protectFormTabs` setting gate: if false, form checking skipped
-3. Form checker injected on-demand via `chrome.scripting.executeScript()` when:
-   - Auto-unload timer fires AND `protectFormTabs` enabled
-   - Memory check executes AND needs per-tab heap data
-4. Permission recovery: if user revokes access, banner appears in options with "Grant permission" button
-5. `permissions.requestHostPermissions()` uses `chrome.permissions.request()` with silent fallback
+3. Form checker injected via `chrome.scripting.executeScript()` from two paths:
+   - **Eager** (`tabs.onUpdated` with `status="complete"`): so the input listener registers before the user types — required for React-controlled inputs and contenteditable editors (Lexical/ProseMirror) where `value`/`defaultValue` tracking is unreliable
+   - **Lazy** (auto-unload timer / memory check): catches tabs already open before the extension loaded
+4. On any keystroke, form-checker sets a global `document.body.dataset.tabrestFormModified` flag — single robust signal that survives SPA navigation and React re-renders
+5. Permission recovery: if user revokes access, banner appears in options with "Grant permission" button
+6. `permissions.requestHostPermissions()` uses `chrome.permissions.request()` with silent fallback
 
 **Rationale:**
 
 - User can protect unsaved forms without granting hosts permission upfront
 - Reduced trust friction on install (optional rather than required)
-- Form-checker stays lazy; only loaded when needed
+- Eager injection is the only reliable way to detect modifications in modern rich-text editors (which never expose values via `defaultValue`)
 
 ### Suspend Warning Toast
 

--- a/docs/vi/feature-test-checklist.md
+++ b/docs/vi/feature-test-checklist.md
@@ -164,15 +164,18 @@ Cấu hình tại `chrome://extensions/shortcuts`.
 ## 18. Bảo vệ Pinned / Audio / Form
 
 - [ ] Tab ghim + bật `Protect pinned tabs` → không bao giờ discard qua auto-unload.
+- [ ] Tab ghim + bật `Include pinned tabs` (tức cho phép discard tab ghim) → dòng popup vẫn hiển thị badge "pin" (intrinsic) và filter chip "protected" vẫn count.
 - [ ] Tab phát YouTube + `Protect audio tabs` → không discard.
 - [ ] Tab có form chưa lưu (ví dụ Google Form điền dở) + `Protect form tabs` → không discard; dòng popup hiển thị badge "Form".
+- [ ] Tab có form chưa lưu trên React/contenteditable editor (ví dụ body issue GitHub) → sau khi gõ, dòng popup hiển thị badge "Form" (eager-injection bắt được keystroke).
+- [ ] Tab vừa whitelist vừa pin/audio/form → popup ưu tiên badge cụ thể (pin/audio/form), không hiển thị "safe" — whitelist là priority thấp nhất.
 - [ ] Tắt một protection → tab khớp trở lại đủ điều kiện.
 - [ ] **Force unload** (menu mỗi tab trong popup) override mọi protection.
 
 ## 19. Optional Host Permissions + Form Injector
 - [ ] Cài mới: host permissions KHÔNG cấp mặc định.
 - [ ] Tắt rồi bật `Protect form tabs` → prompt cấp quyền hoặc banner phục hồi xuất hiện.
-- [ ] Cấp quyền → form-checker chỉ inject vào tab được truy cập; xác nhận qua badge popup và DevTools.
+- [ ] Cấp quyền → form-checker eager-inject mỗi khi page load (và lazy-inject với tab đã mở sẵn ở lần check đầu); xác nhận qua badge popup và `window.__tabrestFormCheckLoaded` trong DevTools.
 - [ ] Thu hồi qua `chrome://extensions` → banner phục hồi tái xuất trong popup với CTA "Enable".
 - [ ] Bật `Discarded tab title prefix` → nếu chưa có quyền `scripting`/host, sẽ yêu cầu.
 

--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -328,7 +328,7 @@ chrome.tabs.onActivated.addListener((activeInfo) => {
 });
 
 // Tab updated (navigation complete) - update activity and badge
-chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
   if (changeInfo.status === "complete" || changeInfo.url) {
     updateTabActivity(tabId);
   }
@@ -340,7 +340,19 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
   if (changeInfo.discarded !== undefined) {
     updateBadge();
   }
+  // Eagerly inject form-checker on page load so its input listener registers
+  // before the user types. Otherwise edits to contenteditable editors (e.g.
+  // GitHub's issue body) made prior to the first popup open go undetected.
+  if (changeInfo.status === "complete" && tab?.url?.startsWith("http")) {
+    eagerInjectFormChecker(tabId, tab.url);
+  }
 });
+
+async function eagerInjectFormChecker(tabId, tabUrl) {
+  const settings = await getSettings();
+  if (!settings.protectFormTabs) return;
+  await ensureFormCheckerInjected(tabId, tabUrl);
+}
 
 // Tab removed - clean up activity entry, memory entry, and update badge
 chrome.tabs.onRemoved.addListener((tabId) => {
@@ -574,13 +586,15 @@ async function getTabsWithStatus() {
     const isSnoozed = snoozeInfo.snoozed;
     const isProtected = isWhitelisted || isPinned || isAudioPlaying || hasFormData || isSnoozed;
 
-    // Determine protection reason for UI display (priority order)
+    // Pin is rendered directly from tab.pinned in the UI (intrinsic property,
+    // shown even when unloadPinnedTabs=true), so it's not part of this chain.
     let protectionReason = null;
-    if (isPinned) protectionReason = "pinned";
-    else if (isWhitelisted) protectionReason = "whitelist";
-    else if (isAudioPlaying) protectionReason = "audio";
-    else if (hasFormData) protectionReason = "form";
-    else if (isSnoozed) protectionReason = "snooze";
+    if (isProtected) {
+      if (isAudioPlaying) protectionReason = "audio";
+      else if (hasFormData) protectionReason = "form";
+      else if (isSnoozed) protectionReason = "snooze";
+      else if (isWhitelisted) protectionReason = "whitelist";
+    }
 
     return {
       id: tab.id,

--- a/src/content/form-checker.js
+++ b/src/content/form-checker.js
@@ -96,6 +96,10 @@ if (!window.__tabrestFormCheckLoaded) {
    * @returns {boolean}
    */
   function checkForUnsavedData() {
+    // Global flag set by input listener — most reliable signal across SPA
+    // navigations, React re-renders, and rich editors (Lexical/ProseMirror).
+    if (document.body?.dataset.tabrestFormModified === "true") return true;
+
     // Check text inputs and textareas - only if MODIFIED from default
     const inputs = document.querySelectorAll(
       'input[type="text"], input[type="email"], input[type="password"], ' +
@@ -135,23 +139,27 @@ if (!window.__tabrestFormCheckLoaded) {
       }
     }
 
-    // Check contenteditable - track via data attribute set on input
+    // Pre-populated rich editor (e.g. GitHub edit-comment) — modern editors
+    // render placeholders via CSS pseudo-elements, so non-empty text implies
+    // user content. Post-injection typing is caught by the global flag above.
     const editables = document.querySelectorAll('[contenteditable="true"]');
     for (const el of editables) {
-      if (el.dataset.tabrestModified === "true") {
-        return true;
-      }
+      if (el.offsetParent === null) continue;
+      if (el.textContent?.trim().length > 0) return true;
     }
 
     return false;
   }
 
-  // Track contenteditable modifications
+  // Mark page as modified on any user input. value/defaultValue tracking is
+  // unreliable for React-controlled inputs and rich editors, so a single
+  // global flag set on the first keystroke is the most robust signal.
+  // Guarded against redundant attribute writes that would re-fire MutationObservers.
   document.addEventListener(
     "input",
-    (e) => {
-      if (e.target.isContentEditable) {
-        e.target.dataset.tabrestModified = "true";
+    () => {
+      if (document.body && document.body.dataset.tabrestFormModified !== "true") {
+        document.body.dataset.tabrestFormModified = "true";
       }
     },
     true,

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -128,9 +128,13 @@ function getStatusBadge(tab) {
   if (tab.discarded) {
     return `<span class="badge badge-sleeping">${icon("moon", 12)} zzz</span>`;
   }
+  // Pin badge shows for any pinned tab, including when unloadPinnedTabs=true
+  // (pin is intrinsic; protectionReason from background omits it for this reason).
+  if (tab.pinned) {
+    return `<span class="badge badge-protected" title="Pinned">${icon("pin", 12)} pin</span>`;
+  }
   if (tab.isProtected) {
     const badges = {
-      pinned: { icon: "pin", text: "pin", title: "Pinned" },
       whitelist: { icon: "shield", text: "safe", title: "Whitelisted" },
       audio: { icon: "volume", text: "audio", title: "Playing audio" },
       form: { icon: "fileText", text: "form", title: "Unsaved form" },
@@ -345,7 +349,9 @@ let cachedTabs = [];
 function getTabCategory(tab) {
   if (tab.discarded) return "sleeping";
   if (tab.isSnoozed) return "snoozed";
-  if (tab.isProtected && !tab.isSnoozed) return "protected";
+  // Match the badge: pinned tabs always count as protected (even when unloadPinnedTabs=true
+  // makes them eligible for unloading), so the filter chip and badge stay in sync.
+  if (tab.isProtected || tab.pinned) return "protected";
   return "active";
 }
 


### PR DESCRIPTION
## Summary

- Pin, audio, and form badges were swallowed by the whitelist "safe" shield whenever the tab also matched a whitelist entry; pinned tabs additionally showed the timer when `Include pinned tabs` was on. Reordered `protectionReason` priority (audio > form > snooze > whitelist) and render pin from intrinsic `tab.pinned` so it always wins for pinned tabs.
- Filter chip "protected" now counts pinned tabs (intrinsic property) regardless of `unloadPinnedTabs` setting.
- Fixed unsaved-form detection on React/contenteditable editors (GitHub issue body, etc.) by eager-injecting form-checker on page load and replacing per-element dataset tracking with a single global flag captured on the first input event — robust against SPA navigation, React re-renders, and rich editors where `value`/`defaultValue` are kept in sync.

## Test plan

- [x] Pinned tab + `Include pinned tabs` ON → popup row shows pin badge (not timer); filter chip count includes it
- [x] Tab playing YouTube audio + whitelisted domain → audio badge wins over shield
- [x] Tab with unsaved form on GitHub `issues/new` (React/contenteditable) → after typing in title or body, form badge shows after switching to another tab
- [x] Plain `<textarea>` form (e.g. partially filled Google Form) → form badge still works
- [x] Whitelist-only tab (no pin/audio/form) → still shows shield "safe" badge
- [x] Force unload (per-tab moon button) still overrides all protections
- [x] All 289 unit tests pass (`pnpm test`)