### PR TITLE
fix: timer badge h/m format + theme toggle alignment

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -145,7 +145,10 @@ function getStatusBadge(tab) {
   }
   if (tab.timeUntilUnload !== null && tab.timeUntilUnload > 0) {
     const mins = Math.ceil(tab.timeUntilUnload / 60000);
-    return `<span class="badge badge-timer" title="Time until auto-unload">${icon("clock", 12)} ${mins}m</span>`;
+    const h = Math.floor(mins / 60);
+    const m = mins % 60;
+    const label = h === 0 ? `${m}m` : m === 0 ? `${h}h` : `${h}h${m}m`;
+    return `<span class="badge badge-timer" title="Time until auto-unload">${icon("clock", 12)} ${label}</span>`;
   }
   return "";
 }

--- a/website/src/components/ThemeToggle.astro
+++ b/website/src/components/ThemeToggle.astro
@@ -4,7 +4,7 @@ import Icon from './Icon.astro';
 ---
 
 <button
-  class="theme-toggle p-2 rounded-lg border border-border-light dark:border-border-dark hover:bg-card-light dark:hover:bg-card-dark transition-colors cursor-pointer text-text-muted dark:text-text-muted-dark hover:text-text dark:hover:text-text-dark"
+  class="theme-toggle inline-flex items-center justify-center p-2 rounded-lg border border-border-light dark:border-border-dark hover:bg-card-light dark:hover:bg-card-dark transition-colors cursor-pointer text-text-muted dark:text-text-muted-dark hover:text-text dark:hover:text-text-dark"
   aria-label="Toggle theme"
   type="button"
 >


### PR DESCRIPTION
## Summary
- Popup timer badge now formats `>= 60` minutes as `XhYm` (e.g. `4h`, `2h15m`) instead of `240m`.
- Website `ThemeToggle` button uses `inline-flex` + `items-center justify-center` so the icon centers cleanly inside the padded square.

## Test plan
- [x] Load extension, set Auto-unload to 1h+, open popup → timer badge reads `Xh` / `XhYm`, never `>=60m`.
- [x] Set Auto-unload to <1h → badge still reads `Ym` as before.
- [x] Open website, toggle theme → icon stays visually centered in the button across light/dark.