### PR TITLE
fix(error-reporter): route manual bug reports through SW with anti-spam throttle

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -721,5 +721,13 @@
   "reportSentFailed": {
     "message": "Failed to send. Try GitHub copy instead.",
     "description": "Toast shown when Sentry bug report submission fails"
+  },
+  "reportCooldown": {
+    "message": "Please wait a minute before sending another report.",
+    "description": "Toast shown when user submits bug reports too quickly"
+  },
+  "reportDailyCap": {
+    "message": "Daily report limit reached. Use GitHub copy instead.",
+    "description": "Toast shown when user has reached daily manual report cap"
   }
 }

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -542,5 +542,11 @@
   },
   "reportSentFailed": {
     "message": "Gửi thất bại. Hãy thử sao chép cho GitHub."
+  },
+  "reportCooldown": {
+    "message": "Vui lòng chờ 1 phút trước khi gửi báo cáo tiếp theo."
+  },
+  "reportDailyCap": {
+    "message": "Đã đạt giới hạn báo cáo trong ngày. Hãy sao chép cho GitHub."
   }
 }

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -482,12 +482,18 @@ Embedded in `src/shared/constants.js:SENTRY_DSN`. Users can optionally override 
 
 ### Rate Limiting & Dedup
 
-| Aspect              | Limit                                                              |
-| ------------------- | ------------------------------------------------------------------ |
-| **Daily cap**       | 100 events/day/user, UTC midnight reset                            |
-| **Dedup window**    | 24 hours (FNV-1a fingerprint of error name + first 3 stack frames) |
-| **Repeat sampling** | 0.1 sample rate for duplicate fingerprints (send 10% of repeats)   |
-| **Dedup table max** | LRU evict at 100 entries to prevent unbounded memory               |
+Auto errors and manual bug reports have **independent caps** so a noisy user-initiated reporter cannot crowd out genuine error events.
+
+| Aspect                     | Limit                                                              |
+| -------------------------- | ------------------------------------------------------------------ |
+| **Auto-error daily cap**   | 100 events/day/user, UTC midnight reset                            |
+| **Dedup window**           | 24 hours (FNV-1a fingerprint of error name + first 3 stack frames) |
+| **Repeat sampling**        | 0.1 sample rate for duplicate fingerprints (send 10% of repeats)   |
+| **Dedup table max**        | LRU evict at 100 entries to prevent unbounded memory               |
+| **Manual report cap**      | 5/day/user, UTC midnight reset (separate from auto-error cap)      |
+| **Manual report cooldown** | 60 s between submits, blocks rapid-fire / double-click             |
+
+Manual reports bypass dedup (intentional submission) and skip the auto-error daily counter — exhausting the manual cap does not consume auto-error quota.
 
 ### Error Surfaces (Tags)
 

--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -4,7 +4,12 @@ import {
   FORM_CHECK_TIMEOUT_MS,
   REPORTER_COMMANDS,
 } from "../shared/constants.js";
-import { captureError, captureMessage, initErrorReporter } from "../shared/error-reporter.js";
+import {
+  captureError,
+  captureMessage,
+  initErrorReporter,
+  reportBug,
+} from "../shared/error-reporter.js";
 import { HOST_PERM_DEPENDENT_FLAGS, hasHostPermission } from "../shared/permissions.js";
 import { getSettings, saveSettings } from "../shared/storage.js";
 import { isMinorOrMajorBump, isValidDomainOrIp, unwrapHostname } from "../shared/utils.js";
@@ -57,6 +62,12 @@ import {
   discardTabsToRight,
   isUrlWhitelisted,
 } from "./unload-manager.js";
+
+// MV3 service workers can be killed and re-awoken by events (messages, alarms)
+// without firing onStartup/onInstalled. Kick init off on every script load so a
+// cold-wake message handler still has parsedDsn ready. initErrorReporter is
+// idempotent — subsequent calls return early.
+initErrorReporter().catch((e) => console.error("[ErrorReporter] eager init failed:", e));
 
 // Side-panel mode takes precedence over toolbarClickAction.
 async function configureToolbarAction() {
@@ -496,6 +507,16 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     captureMessage(message.message || "", message.level || "info", message.context || {});
     sendResponse({ ok: true });
     return false;
+  }
+  if (message.command === REPORTER_COMMANDS.REPORT_BUG) {
+    // Await init so a cold-wake message doesn't race with DSN setup —
+    // otherwise reportBug returns {ok:true, reason:"no_dsn"} and the popup
+    // shows a misleading success toast while Sentry receives nothing.
+    initErrorReporter()
+      .then(() => reportBug(message.description || "", message.diagnostics || null))
+      .then((result) => sendResponse(result))
+      .catch(() => sendResponse({ ok: false, reason: "send_failed" }));
+    return true;
   }
 
   handleMessage(message).then((result) => {

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -1,4 +1,5 @@
-import { reportBug, sanitizeString } from "../shared/error-reporter.js";
+import { REPORT_REASONS, REPORTER_COMMANDS } from "../shared/constants.js";
+import { sanitizeString } from "../shared/error-reporter.js";
 import { localizeHtml, t } from "../shared/i18n.js";
 import { icon, injectIcons } from "../shared/icons.js";
 import { exportPayload, parseImport } from "../shared/import-export.js";
@@ -973,11 +974,19 @@ function setupEventListeners() {
     const description = sanitizeString(elements.bugDescription.value.trim());
     elements.sendToSentryBtn.disabled = true;
     try {
-      const ok = await reportBug(description, cachedDiagnostics);
-      if (ok) {
+      const response = await chrome.runtime.sendMessage({
+        command: REPORTER_COMMANDS.REPORT_BUG,
+        description,
+        diagnostics: cachedDiagnostics,
+      });
+      if (response?.ok === true) {
         showToast(t("reportSentSuccess") || "Report sent. Thank you!");
         elements.bugReportModal.style.display = "none";
         elements.bugDescription.value = "";
+      } else if (response?.reason === REPORT_REASONS.COOLDOWN) {
+        showToast(t("reportCooldown") || "Please wait a minute before sending another report.");
+      } else if (response?.reason === REPORT_REASONS.DAILY_CAP) {
+        showToast(t("reportDailyCap") || "Daily report limit reached. Use GitHub copy instead.");
       } else {
         showToast(t("reportSentFailed") || "Failed to send. Try GitHub copy instead.");
       }

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -548,6 +548,8 @@ async function renderDetailedStats() {
 // Review prompt URLs
 const REVIEW_URL = "https://chromewebstore.google.com/detail/tabrest/placeholder-id/reviews";
 const ISSUES_URL = "https://github.com/lamngockhuong/tabrest/issues";
+const NEW_BUG_ISSUE_URL =
+  "https://github.com/lamngockhuong/tabrest/issues/new?template=bug_report.md";
 
 // Check and show review prompt
 async function checkReviewPrompt() {
@@ -964,7 +966,7 @@ function setupEventListeners() {
     } catch {
       showToast("Failed to copy. Please copy manually.");
     }
-    chrome.tabs.create({ url: "https://github.com/lamngockhuong/tabrest/issues/new" });
+    chrome.tabs.create({ url: NEW_BUG_ISSUE_URL });
     elements.bugReportModal.style.display = "none";
     elements.bugDescription.value = "";
   });

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -107,6 +107,13 @@ export const ERROR_DEDUP_WINDOW_MS = 86400000; // 24 hours
 export const ERROR_REPEAT_SAMPLE_RATE = 0.1;
 export const ERROR_DEDUP_MAX_ENTRIES = 100;
 
+// Anti-spam guards for user-initiated bug reports.
+// Manual reports bypass error dedup, so they need their own throttle to
+// prevent a malicious or impatient user from burning the shared daily cap.
+export const MANUAL_REPORT_STATE_KEY = "manual_report_throttle";
+export const MANUAL_REPORT_DAILY_CAP = 5;
+export const MANUAL_REPORT_COOLDOWN_MS = 60000; // 1 minute between submits
+
 // One-time flag: marks that consent was reset to opt-in default during the
 // v0.0.5 → v0.1.0 migration. Without this guard, every future extension update
 // would silently re-flip a user's enabled opt-in back to false.
@@ -127,6 +134,14 @@ export const SURFACES = Object.freeze({
 export const REPORTER_COMMANDS = Object.freeze({
   CAPTURE_ERROR: "captureError",
   CAPTURE_MESSAGE: "captureMessage",
+  REPORT_BUG: "reportBug",
+});
+
+export const REPORT_REASONS = Object.freeze({
+  COOLDOWN: "cooldown",
+  DAILY_CAP: "daily_cap",
+  SEND_FAILED: "send_failed",
+  NO_DSN: "no_dsn",
 });
 
 // Sentry DSN for anonymous crash reporting.

--- a/src/shared/error-reporter.js
+++ b/src/shared/error-reporter.js
@@ -9,6 +9,10 @@ import {
   ERROR_DEDUP_WINDOW_MS,
   ERROR_QUOTA_KEY,
   ERROR_REPEAT_SAMPLE_RATE,
+  MANUAL_REPORT_COOLDOWN_MS,
+  MANUAL_REPORT_DAILY_CAP,
+  MANUAL_REPORT_STATE_KEY,
+  REPORT_REASONS,
   SENTRY_DSN,
   SURFACES,
 } from "./constants.js";
@@ -159,10 +163,9 @@ export function captureMessage(message, level = "info", context = {}) {
 
 /**
  * Submit a manual bug report.
- * Always returns a Promise<boolean> so callers have a uniform contract.
  * @param {string} description - User's description of the issue
  * @param {Object} diagnostics - Sanitized diagnostic data from log-collector
- * @returns {Promise<boolean>} true on success (or local-only fallback when DSN absent)
+ * @returns {Promise<{ok: boolean, reason?: "cooldown"|"daily_cap"|"send_failed"|"no_dsn"}>}
  */
 export async function reportBug(description, diagnostics) {
   const sanitizedDescription = sanitizeString(description);
@@ -179,11 +182,19 @@ export async function reportBug(description, diagnostics) {
 
   storeReport(report);
 
-  if (parsedDsn && sentryInitialized) {
-    return sendReportToSentry(report);
+  if (!(parsedDsn && sentryInitialized)) {
+    return { ok: true, reason: REPORT_REASONS.NO_DSN };
   }
 
-  return true;
+  const throttle = await checkManualReportThrottle();
+  if (!throttle.allowed) return { ok: false, reason: throttle.reason };
+
+  const sent = await sendReportToSentry(report);
+  if (!sent) return { ok: false, reason: REPORT_REASONS.SEND_FAILED };
+
+  // Fire-and-forget: popup doesn't need to wait for storage write.
+  commitManualReportThrottle(throttle.state).catch(() => {});
+  return { ok: true };
 }
 
 // --- Internal Storage ---
@@ -311,6 +322,39 @@ async function checkAndIncrementQuota() {
   quota.count++;
   await chrome.storage.local.set({ [ERROR_QUOTA_KEY]: quota });
   return { allowed: true, count: quota.count, cap: ERROR_DAILY_CAP };
+}
+
+/**
+ * Anti-spam guard for manual bug reports. Two-phase: caller invokes this to
+ * check eligibility, then commitManualReportThrottle after a successful send
+ * so failed sends don't burn the daily cap.
+ * @returns {Promise<{allowed: boolean, reason?: "cooldown"|"daily_cap", state: Object}>}
+ */
+async function checkManualReportThrottle() {
+  const today = getTodayUtc();
+  const now = Date.now();
+  const data = await chrome.storage.local.get(MANUAL_REPORT_STATE_KEY);
+  let state = data[MANUAL_REPORT_STATE_KEY] || { date: today, count: 0, lastAt: 0 };
+  if (state.date !== today) state = { date: today, count: 0, lastAt: 0 };
+
+  if (now - state.lastAt < MANUAL_REPORT_COOLDOWN_MS) {
+    return { allowed: false, reason: REPORT_REASONS.COOLDOWN, state };
+  }
+  if (state.count >= MANUAL_REPORT_DAILY_CAP) {
+    return { allowed: false, reason: REPORT_REASONS.DAILY_CAP, state };
+  }
+  return { allowed: true, state };
+}
+
+/**
+ * Persist throttle state after a successful manual report send.
+ * Non-mutating: writes a fresh object so callers can't accidentally observe
+ * mid-flight mutations.
+ * @param {Object} state - state object returned by checkManualReportThrottle
+ */
+async function commitManualReportThrottle(state) {
+  const next = { ...state, count: state.count + 1, lastAt: Date.now() };
+  await chrome.storage.local.set({ [MANUAL_REPORT_STATE_KEY]: next });
 }
 
 /**
@@ -710,15 +754,14 @@ async function sendMessageToSentry(sanitizedMessage, level, context) {
 
 /**
  * Send a manual bug report to Sentry.
- * Bypasses dedup (manual reports are intentional); still respects daily cap.
- * Returns a promise resolving to true if the send succeeded, false otherwise.
+ * Manual reports have their own cap (checkManualReportThrottle) and must NOT
+ * burn the shared error daily cap — otherwise a noisy reporter would crowd
+ * out genuine error events.
  * @param {Object} report
  * @returns {Promise<boolean>}
  */
 async function sendReportToSentry(report) {
   try {
-    const quota = await checkAndIncrementQuota();
-    if (!quota.allowed) return false; // quota exhausted — signal to caller
     const payload = buildManualReportPayload(report);
     const envelope = buildEnvelope(payload, rawDsn);
     const result = await sendEnvelope(envelope, parsedDsn.ingestUrl, cachedAuthHeader);
@@ -749,4 +792,6 @@ export const __test__ = {
   checkDedup,
   recordSend,
   persistDedup,
+  checkManualReportThrottle,
+  commitManualReportThrottle,
 };

--- a/tests/popup/bug-report-modal.test.js
+++ b/tests/popup/bug-report-modal.test.js
@@ -75,40 +75,33 @@ describe("bug-report-modal: reportBug behavior", () => {
     chrome.runtime.getManifest.mockReturnValue({ version: "0.0.5" });
   });
 
-  it("reportBug returns boolean or Promise<boolean>", async () => {
-    const result = reportBug("test report", { mock: true });
-
-    // Result can be boolean or Promise<boolean>
-    const normalized = await Promise.resolve(result);
-    expect(typeof normalized).toBe("boolean");
+  it("reportBug resolves to {ok, reason?}", async () => {
+    const result = await reportBug("test report", { mock: true });
+    expect(result).toMatchObject({ ok: expect.any(Boolean) });
   });
 
   it("reportBug accepts description and diagnostics", async () => {
     const description = "Bug description";
     const diagnostics = { tabCount: 5, memoryMB: 100 };
 
-    // Should not throw
-    await expect(Promise.resolve(reportBug(description, diagnostics))).resolves.toBeDefined();
+    await expect(reportBug(description, diagnostics)).resolves.toBeDefined();
   });
 
   it("reportBug sanitizes description with PII", async () => {
     const description = "Error from https://secret.com";
 
-    // reportBug internally sanitizes
-    const result = await Promise.resolve(reportBug(description, {}));
-    expect(typeof result).toBe("boolean");
+    const result = await reportBug(description, {});
+    expect(result).toMatchObject({ ok: expect.any(Boolean) });
   });
 
   it("reportBug handles empty description", async () => {
-    const result = reportBug("", {});
-    const normalized = await Promise.resolve(result);
-    expect(typeof normalized).toBe("boolean");
+    const result = await reportBug("", {});
+    expect(result).toMatchObject({ ok: expect.any(Boolean) });
   });
 
   it("reportBug handles null diagnostics gracefully", async () => {
-    const result = reportBug("test", null);
-    const normalized = await Promise.resolve(result);
-    expect(typeof normalized).toBe("boolean");
+    const result = await reportBug("test", null);
+    expect(result).toMatchObject({ ok: expect.any(Boolean) });
   });
 });
 

--- a/tests/shared/error-reporter-storage.test.js
+++ b/tests/shared/error-reporter-storage.test.js
@@ -103,13 +103,13 @@ describe("error-reporter (storage + capture)", () => {
   });
 
   describe("reportBug", () => {
-    it("returns true and stores sanitized report", async () => {
+    it("returns ok and stores sanitized report", async () => {
       chrome.storage.local.get.mockResolvedValue({});
       chrome.storage.local.set.mockResolvedValue();
       chrome.runtime.getManifest.mockReturnValue({ version: "0.0.5" });
 
-      const ok = await reportBug("Bug at https://leak.com", { tabs: 5 });
-      expect(ok).toBe(true);
+      const result = await reportBug("Bug at https://leak.com", { tabs: 5 });
+      expect(result).toEqual({ ok: true, reason: "no_dsn" });
 
       await vi.waitFor(() => expect(chrome.storage.local.set).toHaveBeenCalled());
       const written = chrome.storage.local.set.mock.calls[0][0][BUG_REPORTS_KEY];


### PR DESCRIPTION
## Summary

- Manual bug reports (popup → 🐛) never reached Sentry: popup imported `reportBug` directly, but module-scope `parsedDsn` / `sentryInitialized` only get populated in the service worker. Route reports through the runtime message bridge so the SW (the only context that calls `initErrorReporter`) handles transport.
- Manual reports were burning the shared 100/day auto-error cap. Add a separate cap (5/day) + 60s cooldown so a noisy reporter cannot crowd out genuine errors.
- MV3 cold-wake hardening: SW killed after idle and re-awoken by a message would skip `onStartup`/`onInstalled` and leave `parsedDsn = null`. Add an eager `initErrorReporter()` at module top + `await` init in the REPORT_BUG handler.

## Behavior changes

| Before | After |
|---|---|
| Popup `reportBug` → only local-stored, never sent | Popup → `chrome.runtime.sendMessage` → SW `reportBug` → Sentry |
| Manual reports counted against the 100/day auto-error cap | Manual reports have a dedicated 5/day cap + 60s cooldown |
| `reportBug` returned `boolean` | Returns `{ ok: boolean, reason?: "cooldown" \| "daily_cap" \| "send_failed" \| "no_dsn" }` so popup can show specific toast |
| SW cold-wake by message left reporter uninitialized | Eager init on every SW load + `await` init in handler |

## Files

- `src/shared/error-reporter.js` — throttle helpers, new return shape, fire-and-forget commit, `sendReportToSentry` no longer touches shared quota
- `src/shared/constants.js` — `REPORTER_COMMANDS.REPORT_BUG`, `REPORT_REASONS`, `MANUAL_REPORT_*` constants
- `src/background/service-worker.js` — eager init + REPORT_BUG bridge handler
- `src/popup/popup.js` — sendMessage path, reason-aware toasts
- `_locales/{en,vi}/messages.json` — `reportCooldown` / `reportDailyCap` strings
- `docs/system-architecture.md` — Rate Limiting & Dedup section updated
- Tests updated for new return shape (405 passing)

## Test plan

- [ ] Reload extension; SW console shows `[ErrorReporter] Initialized` on script load
- [ ] Submit bug report from popup → Sentry receives event tagged `surface: manual_report`
- [ ] Submit a 2nd report within 60s → toast shows cooldown message; no Sentry event
- [ ] Submit 5 reports throughout the day → 6th is blocked with daily-cap toast
- [ ] After failed network send (e.g., DSN unreachable) → counter does not increment; user can retry
- [ ] After SW idle 30+ s, popup submit still reaches Sentry (cold-wake init verified)