### PR TITLE
fix(release-please): bump minor for feat commits in pre-1.0.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,7 @@
       "changelog-path": "CHANGELOG.md",
       "release-type": "node",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": false,
       "extra-files": ["manifest.json", "package.json"]
     }
   }


### PR DESCRIPTION
## Summary
- `bump-patch-for-minor-pre-major: true` was overriding `bump-minor-pre-major: true`, forcing every `feat` commit to bump patch instead of minor while we're still in pre-1.0.0.
- Result: release-please PR #45 produced `0.0.6` after the Sentry + granular settings features, instead of the expected `0.1.0`.
- Setting `bump-patch-for-minor-pre-major: false` restores normal SemVer-pre-major behaviour: `feat` → minor, `fix` → patch.

## Test plan
- [x] After merge, release-please re-runs on `main` and updates PR #45 (or replaces it) with `0.1.0`.
- [x] Changelog entry lists Sentry + settings under `Features`, fixes under `Bug Fixes`.
- [x] `manifest.json` and `package.json` get bumped to `0.1.0` by the release PR.