### PR TITLE
feat(onboarding): interactive multi-step setup wizard

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -730,17 +730,9 @@
     "message": "Daily report limit reached. Use GitHub copy instead.",
     "description": "Toast shown when user has reached daily manual report cap"
   },
-  "optionsSetupHeading": {
-    "message": "Setup",
-    "description": "Options page section heading for onboarding re-run"
-  },
   "optionsRerunOnboarding": {
     "message": "Run setup again",
-    "description": "Options page button to reopen the onboarding wizard"
-  },
-  "optionsRerunOnboardingHelp": {
-    "message": "Run the welcome tour again to retune the most-used settings.",
-    "description": "Options page help text under the rerun-onboarding button"
+    "description": "Options page footer link to reopen the onboarding wizard"
   },
   "obWizardTitle": {
     "message": "TabRest setup",

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -729,5 +729,193 @@
   "reportDailyCap": {
     "message": "Daily report limit reached. Use GitHub copy instead.",
     "description": "Toast shown when user has reached daily manual report cap"
+  },
+  "optionsSetupHeading": {
+    "message": "Setup",
+    "description": "Options page section heading for onboarding re-run"
+  },
+  "optionsRerunOnboarding": {
+    "message": "Run setup again",
+    "description": "Options page button to reopen the onboarding wizard"
+  },
+  "optionsRerunOnboardingHelp": {
+    "message": "Run the welcome tour again to retune the most-used settings.",
+    "description": "Options page help text under the rerun-onboarding button"
+  },
+  "obWizardTitle": {
+    "message": "TabRest setup",
+    "description": "Onboarding wizard header title"
+  },
+  "obSkipAll": {
+    "message": "Skip all",
+    "description": "Header link to close the entire onboarding wizard without configuring"
+  },
+  "obBack": {
+    "message": "Back",
+    "description": "Onboarding wizard back button"
+  },
+  "obNext": {
+    "message": "Next",
+    "description": "Onboarding wizard next button"
+  },
+  "obSkip": {
+    "message": "Skip",
+    "description": "Onboarding wizard per-step skip button"
+  },
+  "obFinish": {
+    "message": "Finish",
+    "description": "Onboarding wizard final-step finish button"
+  },
+  "obProgressLabel": {
+    "message": "Step $1 of $2",
+    "description": "Onboarding aria-live progress announcement",
+    "placeholders": {
+      "1": { "content": "$1" },
+      "2": { "content": "$2" }
+    }
+  },
+  "obWelcomeTitle": {
+    "message": "Welcome to TabRest",
+    "description": "Onboarding step 1 heading"
+  },
+  "obWelcomeBody": {
+    "message": "A quick setup tunes TabRest for the way you browse. You can change anything later in Settings.",
+    "description": "Onboarding step 1 body paragraph"
+  },
+  "obWelcomeStart": {
+    "message": "Let's set up",
+    "description": "Onboarding step 1 primary CTA"
+  },
+  "obAutoUnloadTitle": {
+    "message": "Auto-unload inactive tabs",
+    "description": "Onboarding step 2 heading"
+  },
+  "obAutoUnloadDesc": {
+    "message": "Pick how long an inactive tab waits before being unloaded.",
+    "description": "Onboarding step 2 description"
+  },
+  "obAutoUnloadOpt30": {
+    "message": "30 minutes",
+    "description": "Onboarding auto-unload 30 minute option"
+  },
+  "obAutoUnloadOpt60": {
+    "message": "1 hour",
+    "description": "Onboarding auto-unload 60 minute option"
+  },
+  "obAutoUnloadOpt120": {
+    "message": "2 hours",
+    "description": "Onboarding auto-unload 120 minute option"
+  },
+  "obWhitelistTitle": {
+    "message": "Always keep these awake",
+    "description": "Onboarding step 3 heading"
+  },
+  "obWhitelistDesc": {
+    "message": "Sites you check are protected from auto-unload.",
+    "description": "Onboarding step 3 description"
+  },
+  "obWhitelistHint": {
+    "message": "You can edit this list later in Settings.",
+    "description": "Onboarding step 3 footer hint"
+  },
+  "obPowerModeTitle": {
+    "message": "Pick a power mode",
+    "description": "Onboarding step 4 heading"
+  },
+  "obPowerModeDesc": {
+    "message": "Choose how aggressively TabRest unloads.",
+    "description": "Onboarding step 4 description"
+  },
+  "obNotificationsTitle": {
+    "message": "Get notified on auto-unload",
+    "description": "Onboarding step 5 heading"
+  },
+  "obNotificationsDesc": {
+    "message": "Show a system notification when TabRest unloads tabs in the background.",
+    "description": "Onboarding step 5 description"
+  },
+  "obNotificationsToggle": {
+    "message": "Notify me when tabs are auto-unloaded",
+    "description": "Onboarding step 5 toggle label"
+  },
+  "obDoneTitle": {
+    "message": "You're all set",
+    "description": "Onboarding step 6 heading"
+  },
+  "obDoneSubtitle": {
+    "message": "Your settings have been saved.",
+    "description": "Onboarding step 6 subtitle"
+  },
+  "obPinTitle": {
+    "message": "Pin TabRest to your toolbar",
+    "description": "Done step pin reminder card title (not pinned yet)"
+  },
+  "obPinDesc": {
+    "message": "Click the puzzle icon in the top-right of your browser, then pin TabRest for one-click access.",
+    "description": "Done step pin reminder card description (not pinned yet)"
+  },
+  "obPinnedTitle": {
+    "message": "Pinned!",
+    "description": "Done step pin card title after the user has pinned the extension"
+  },
+  "obPinnedDesc": {
+    "message": "Click the TabRest icon any time to manage your tabs.",
+    "description": "Done step pin card description after the user has pinned the extension"
+  },
+  "obDoneSummaryDelay": {
+    "message": "Auto-unload after",
+    "description": "Done step summary row label for delay"
+  },
+  "obDoneSummaryWhitelist": {
+    "message": "Always keep awake",
+    "description": "Done step summary row label for whitelist count"
+  },
+  "obDoneSummaryWhitelistN": {
+    "message": "$1 sites",
+    "description": "Done step summary value for whitelist count",
+    "placeholders": {
+      "1": { "content": "$1" }
+    }
+  },
+  "obDoneSummaryPowerMode": {
+    "message": "Power mode",
+    "description": "Done step summary row label for power mode"
+  },
+  "obDoneSummaryNotifs": {
+    "message": "Notifications",
+    "description": "Done step summary row label for notifications"
+  },
+  "obDoneOpenSettings": {
+    "message": "Open all settings",
+    "description": "Done step link to options page"
+  },
+  "obDoneShortcutsHint": {
+    "message": "Tip: $1 unloads the current tab.",
+    "description": "Done step keyboard shortcuts hint",
+    "placeholders": {
+      "1": { "content": "$1" }
+    }
+  },
+  "obOnState": {
+    "message": "On",
+    "description": "Generic on indicator for done summary"
+  },
+  "obOffState": {
+    "message": "Off",
+    "description": "Generic off indicator for done summary"
+  },
+  "obMinutes": {
+    "message": "$1 min",
+    "description": "Duration in minutes for done summary",
+    "placeholders": {
+      "1": { "content": "$1" }
+    }
+  },
+  "obHours": {
+    "message": "$1 hr",
+    "description": "Duration in hours for done summary",
+    "placeholders": {
+      "1": { "content": "$1" }
+    }
   }
 }

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -549,14 +549,8 @@
   "reportDailyCap": {
     "message": "Đã đạt giới hạn báo cáo trong ngày. Hãy sao chép cho GitHub."
   },
-  "optionsSetupHeading": {
-    "message": "Cài đặt nhanh"
-  },
   "optionsRerunOnboarding": {
     "message": "Chạy lại cài đặt nhanh"
-  },
-  "optionsRerunOnboardingHelp": {
-    "message": "Chạy lại trình hướng dẫn để chỉnh các tuỳ chọn hay dùng nhất."
   },
   "obWizardTitle": {
     "message": "Cài đặt TabRest"

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -548,5 +548,150 @@
   },
   "reportDailyCap": {
     "message": "Đã đạt giới hạn báo cáo trong ngày. Hãy sao chép cho GitHub."
+  },
+  "optionsSetupHeading": {
+    "message": "Cài đặt nhanh"
+  },
+  "optionsRerunOnboarding": {
+    "message": "Chạy lại cài đặt nhanh"
+  },
+  "optionsRerunOnboardingHelp": {
+    "message": "Chạy lại trình hướng dẫn để chỉnh các tuỳ chọn hay dùng nhất."
+  },
+  "obWizardTitle": {
+    "message": "Cài đặt TabRest"
+  },
+  "obSkipAll": {
+    "message": "Bỏ qua tất cả"
+  },
+  "obBack": {
+    "message": "Quay lại"
+  },
+  "obNext": {
+    "message": "Tiếp tục"
+  },
+  "obSkip": {
+    "message": "Bỏ qua"
+  },
+  "obFinish": {
+    "message": "Hoàn tất"
+  },
+  "obProgressLabel": {
+    "message": "Bước $1 trên $2",
+    "placeholders": {
+      "1": { "content": "$1" },
+      "2": { "content": "$2" }
+    }
+  },
+  "obWelcomeTitle": {
+    "message": "Chào mừng đến với TabRest"
+  },
+  "obWelcomeBody": {
+    "message": "Cài đặt nhanh giúp TabRest chạy hợp với cách bạn duyệt web. Bạn có thể đổi mọi tuỳ chọn trong Cài đặt sau."
+  },
+  "obWelcomeStart": {
+    "message": "Bắt đầu thôi"
+  },
+  "obAutoUnloadTitle": {
+    "message": "Tự động giải phóng tab không hoạt động"
+  },
+  "obAutoUnloadDesc": {
+    "message": "Chọn thời gian chờ trước khi tab không hoạt động được giải phóng."
+  },
+  "obAutoUnloadOpt30": {
+    "message": "30 phút"
+  },
+  "obAutoUnloadOpt60": {
+    "message": "1 giờ"
+  },
+  "obAutoUnloadOpt120": {
+    "message": "2 giờ"
+  },
+  "obWhitelistTitle": {
+    "message": "Luôn giữ những trang này hoạt động"
+  },
+  "obWhitelistDesc": {
+    "message": "Các trang được chọn sẽ không bị tự động giải phóng."
+  },
+  "obWhitelistHint": {
+    "message": "Bạn có thể chỉnh danh sách này trong Cài đặt sau."
+  },
+  "obPowerModeTitle": {
+    "message": "Chọn chế độ hoạt động"
+  },
+  "obPowerModeDesc": {
+    "message": "Chọn mức độ giải phóng tab của TabRest."
+  },
+  "obNotificationsTitle": {
+    "message": "Nhận thông báo khi tự động giải phóng"
+  },
+  "obNotificationsDesc": {
+    "message": "Hiển thị thông báo hệ thống khi TabRest giải phóng tab ở chế độ nền."
+  },
+  "obNotificationsToggle": {
+    "message": "Thông báo khi tab được tự động giải phóng"
+  },
+  "obDoneTitle": {
+    "message": "Hoàn tất rồi"
+  },
+  "obDoneSubtitle": {
+    "message": "Cài đặt của bạn đã được lưu."
+  },
+  "obPinTitle": {
+    "message": "Ghim TabRest lên thanh công cụ"
+  },
+  "obPinDesc": {
+    "message": "Bấm biểu tượng puzzle ở góc phải trên trình duyệt rồi ghim TabRest để truy cập nhanh."
+  },
+  "obPinnedTitle": {
+    "message": "Đã ghim!"
+  },
+  "obPinnedDesc": {
+    "message": "Bấm biểu tượng TabRest bất cứ lúc nào để quản lý tab."
+  },
+  "obDoneSummaryDelay": {
+    "message": "Tự động giải phóng sau"
+  },
+  "obDoneSummaryWhitelist": {
+    "message": "Luôn giữ hoạt động"
+  },
+  "obDoneSummaryWhitelistN": {
+    "message": "$1 trang",
+    "placeholders": {
+      "1": { "content": "$1" }
+    }
+  },
+  "obDoneSummaryPowerMode": {
+    "message": "Chế độ hoạt động"
+  },
+  "obDoneSummaryNotifs": {
+    "message": "Thông báo"
+  },
+  "obDoneOpenSettings": {
+    "message": "Mở toàn bộ cài đặt"
+  },
+  "obDoneShortcutsHint": {
+    "message": "Mẹo: $1 sẽ giải phóng tab hiện tại.",
+    "placeholders": {
+      "1": { "content": "$1" }
+    }
+  },
+  "obOnState": {
+    "message": "Bật"
+  },
+  "obOffState": {
+    "message": "Tắt"
+  },
+  "obMinutes": {
+    "message": "$1 phút",
+    "placeholders": {
+      "1": { "content": "$1" }
+    }
+  },
+  "obHours": {
+    "message": "$1 giờ",
+    "placeholders": {
+      "1": { "content": "$1" }
+    }
   }
 }

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -826,7 +826,10 @@ kbd {
 
 /* ---------- Footer ---------- */
 .page-footer {
-  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
   margin-top: 24px;
   padding-top: 16px;
   font-size: 12px;
@@ -841,6 +844,33 @@ kbd {
 
 .footer-brand svg {
   color: var(--accent);
+}
+
+.footer-sep {
+  color: var(--text-muted);
+  opacity: 0.6;
+}
+
+.footer-link {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 0;
+  font-family: inherit;
+  line-height: inherit;
+  text-decoration: underline;
+  text-decoration-color: transparent;
+  text-underline-offset: 2px;
+  transition: color 0.15s, text-decoration-color 0.15s;
+}
+
+.footer-link:hover,
+.footer-link:focus-visible {
+  color: var(--primary);
+  text-decoration-color: currentColor;
+  outline: none;
 }
 
 /* ---------- Scrollbar polish ---------- */

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -385,14 +385,6 @@
         </div>
       </section>
 
-      <section class="card">
-        <header class="card-header">
-          <span class="card-header-icon" data-icon="sliders" data-icon-size="18"></span>
-          <h2 data-i18n="optionsSetupHeading">Setup</h2>
-        </header>
-        <p class="help" data-i18n="optionsRerunOnboardingHelp">Run the welcome tour again to retune the most-used settings.</p>
-        <button id="rerun-onboarding" type="button" class="btn secondary" data-i18n="optionsRerunOnboarding">Run setup again</button>
-      </section>
     </div>
 
     <footer class="page-footer">
@@ -400,6 +392,8 @@
         <span data-icon="heart" data-icon-size="14"></span>
         TabRest &middot; <span data-i18n="footerTagline">Calm tab management</span>
       </span>
+      <span class="footer-sep" aria-hidden="true">·</span>
+      <button id="rerun-onboarding" type="button" class="footer-link" data-i18n="optionsRerunOnboarding">Run setup again</button>
     </footer>
 
     <div id="status" class="status"></div>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -384,6 +384,15 @@
           <div class="shortcut"><kbd>Alt+Shift+Left</kbd> <span data-i18n="unloadLeft">Unload tabs to left</span></div>
         </div>
       </section>
+
+      <section class="card">
+        <header class="card-header">
+          <span class="card-header-icon" data-icon="sliders" data-icon-size="18"></span>
+          <h2 data-i18n="optionsSetupHeading">Setup</h2>
+        </header>
+        <p class="help" data-i18n="optionsRerunOnboardingHelp">Run the welcome tour again to retune the most-used settings.</p>
+        <button id="rerun-onboarding" type="button" class="btn secondary" data-i18n="optionsRerunOnboarding">Run setup again</button>
+      </section>
     </div>
 
     <footer class="page-footer">

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -60,6 +60,7 @@ const elements = {
   resetStats: document.getElementById("reset-stats"),
   status: document.getElementById("status"),
   shortcutsLink: document.getElementById("shortcuts-link"),
+  rerunOnboarding: document.getElementById("rerun-onboarding"),
   enableErrorReporting: document.getElementById("enable-error-reporting"),
   customSentryDsn: document.getElementById("custom-sentry-dsn"),
   dsnValidationMsg: document.getElementById("dsn-validation-msg"),
@@ -364,6 +365,11 @@ function setupEventListeners() {
   elements.themeToggle.addEventListener("click", async () => {
     const newTheme = await toggleTheme();
     updateThemeIcon(elements.themeIcon, elements.themeToggle, newTheme);
+  });
+
+  // Re-run onboarding wizard
+  elements.rerunOnboarding?.addEventListener("click", () => {
+    chrome.tabs.create({ url: chrome.runtime.getURL("src/pages/onboarding.html") });
   });
 }
 

--- a/src/pages/onboarding.html
+++ b/src/pages/onboarding.html
@@ -4,66 +4,96 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="pages.css">
+  <link rel="stylesheet" href="onboarding/onboarding.css">
   <title>Welcome to TabRest</title>
 </head>
 <body>
-  <div class="page-container">
-    <header class="page-header">
-      <img src="../../icons/icon-128.png" alt="TabRest" class="page-logo">
-      <h1 class="page-title">Welcome to TabRest</h1>
-      <p class="page-subtitle">Rest your tabs, free your memory</p>
-    </header>
-
-    <div class="feature-list">
-      <div class="feature-item">
-        <div class="feature-icon">
-          <span data-icon="moon" data-icon-size="18"></span>
-        </div>
-        <div class="feature-content">
-          <h3>Automatic Tab Unloading</h3>
-          <p>Inactive tabs are automatically unloaded after a set time, freeing up memory while preserving your browsing state.</p>
-        </div>
+  <div class="page-container wizard-root">
+    <div class="wizard-header">
+      <div class="wizard-title-block">
+        <img src="../../icons/icon-128.png" alt="TabRest" class="page-logo" style="width: 40px; height: 40px;">
+        <h1 class="page-title" style="font-size: 18px;" data-i18n="obWizardTitle">TabRest setup</h1>
       </div>
-
-      <div class="feature-item">
-        <div class="feature-icon">
-          <span data-icon="shield" data-icon-size="18"></span>
-        </div>
-        <div class="feature-content">
-          <h3>Smart Protection</h3>
-          <p>Pinned tabs, tabs playing audio, and tabs with unsaved forms are automatically protected from unloading.</p>
-        </div>
-      </div>
-
-      <div class="feature-item">
-        <div class="feature-icon">
-          <span data-icon="folderOpen" data-icon-size="18"></span>
-        </div>
-        <div class="feature-content">
-          <h3>Session Management</h3>
-          <p>Save your current tabs as a session and restore them anytime. Never lose your workflow again.</p>
-        </div>
-      </div>
-
-      <div class="feature-item">
-        <div class="feature-icon">
-          <span data-icon="barChart" data-icon-size="18"></span>
-        </div>
-        <div class="feature-content">
-          <h3>Usage Statistics</h3>
-          <p>Track how many tabs you've unloaded and estimate your memory savings over time.</p>
-        </div>
-      </div>
+      <button type="button" class="skip-all-link" data-action="skip-all" data-i18n="obSkipAll">Skip all</button>
     </div>
 
-    <div class="cta-section">
-      <button class="btn-large btn-primary" id="btn-get-started">
-        Get Started
-      </button>
-      <p style="margin-top: 12px; font-size: 12px; color: var(--text-muted);">
-        Click the TabRest icon in your toolbar to begin
-      </p>
+    <div class="wizard-progress" role="progressbar" aria-valuemin="1" aria-valuemax="6" aria-valuenow="1">
+      <div class="wizard-progress-fill"></div>
     </div>
+
+    <main class="wizard-stage">
+      <section class="wizard-step is-active" data-step-id="welcome">
+        <h2 data-i18n="obWelcomeTitle">Welcome to TabRest</h2>
+        <p data-i18n="obWelcomeBody">A quick setup tunes TabRest for the way you browse. You can change anything later in Settings.</p>
+        <div class="wizard-nav">
+          <span class="wizard-nav-spacer"></span>
+          <button type="button" class="btn-large btn-primary" data-action="next" data-i18n="obWelcomeStart">Let's set up</button>
+        </div>
+      </section>
+
+      <section class="wizard-step" data-step-id="auto-unload" inert>
+        <h2 data-i18n="obAutoUnloadTitle">Auto-unload inactive tabs</h2>
+        <p data-i18n="obAutoUnloadDesc">Pick how long an inactive tab waits before being unloaded.</p>
+        <div data-step-body></div>
+        <div class="wizard-nav">
+          <button type="button" class="btn-outline" data-action="back" data-i18n="obBack">Back</button>
+          <span class="wizard-nav-spacer"></span>
+          <button type="button" class="btn-ghost" data-action="skip" data-i18n="obSkip">Skip</button>
+          <button type="button" class="btn-large btn-primary" data-action="next" data-i18n="obNext">Next</button>
+        </div>
+      </section>
+
+      <section class="wizard-step" data-step-id="whitelist" inert>
+        <h2 data-i18n="obWhitelistTitle">Always keep these awake</h2>
+        <p data-i18n="obWhitelistDesc">Sites you check are protected from auto-unload.</p>
+        <div data-step-body></div>
+        <p class="hint" data-i18n="obWhitelistHint">You can edit this list later in Settings.</p>
+        <div class="wizard-nav">
+          <button type="button" class="btn-outline" data-action="back" data-i18n="obBack">Back</button>
+          <span class="wizard-nav-spacer"></span>
+          <button type="button" class="btn-ghost" data-action="skip" data-i18n="obSkip">Skip</button>
+          <button type="button" class="btn-large btn-primary" data-action="next" data-i18n="obNext">Next</button>
+        </div>
+      </section>
+
+      <section class="wizard-step" data-step-id="power-mode" inert>
+        <h2 data-i18n="obPowerModeTitle">Pick a power mode</h2>
+        <p data-i18n="obPowerModeDesc">Choose how aggressively TabRest unloads.</p>
+        <div data-step-body></div>
+        <div class="wizard-nav">
+          <button type="button" class="btn-outline" data-action="back" data-i18n="obBack">Back</button>
+          <span class="wizard-nav-spacer"></span>
+          <button type="button" class="btn-ghost" data-action="skip" data-i18n="obSkip">Skip</button>
+          <button type="button" class="btn-large btn-primary" data-action="next" data-i18n="obNext">Next</button>
+        </div>
+      </section>
+
+      <section class="wizard-step" data-step-id="notifications" inert>
+        <h2 data-i18n="obNotificationsTitle">Get notified on auto-unload</h2>
+        <p data-i18n="obNotificationsDesc">Show a system notification when TabRest unloads tabs in the background.</p>
+        <div data-step-body></div>
+        <div class="wizard-nav">
+          <button type="button" class="btn-outline" data-action="back" data-i18n="obBack">Back</button>
+          <span class="wizard-nav-spacer"></span>
+          <button type="button" class="btn-ghost" data-action="skip" data-i18n="obSkip">Skip</button>
+          <button type="button" class="btn-large btn-primary" data-action="next" data-i18n="obNext">Next</button>
+        </div>
+      </section>
+
+      <section class="wizard-step" data-step-id="done" inert>
+        <span class="ob-done-badge" aria-hidden="true" data-icon="check" data-icon-size="24"></span>
+        <h2 data-i18n="obDoneTitle">You're all set</h2>
+        <p data-i18n="obDoneSubtitle">Your settings have been saved.</p>
+        <div data-step-body></div>
+        <div class="wizard-nav">
+          <button type="button" class="btn-outline" data-action="back" data-i18n="obBack">Back</button>
+          <span class="wizard-nav-spacer"></span>
+          <button type="button" class="btn-large btn-primary" data-action="finish" data-i18n="obFinish">Finish</button>
+        </div>
+      </section>
+    </main>
+
+    <div class="sr-only" aria-live="polite" id="wizard-announcer"></div>
   </div>
 
   <script src="onboarding.js" type="module"></script>

--- a/src/pages/onboarding.js
+++ b/src/pages/onboarding.js
@@ -1,17 +1,14 @@
-// Onboarding page script
+// Onboarding page entry: boots theme, i18n, icons, then mounts the wizard.
+
+import { localizeHtml } from "../shared/i18n.js";
 import { injectIcons } from "../shared/icons.js";
 import { initTheme, onThemeChange } from "../shared/theme.js";
+import { mountWizard } from "./onboarding/wizard.js";
 
 document.addEventListener("DOMContentLoaded", async () => {
-  // Sync theme with other pages (popup/options)
   await initTheme();
   onThemeChange();
-
-  // Inject icons
+  localizeHtml();
   injectIcons();
-
-  // Close button handler
-  document.getElementById("btn-get-started").addEventListener("click", () => {
-    window.close();
-  });
+  mountWizard(document.querySelector(".wizard-root"));
 });

--- a/src/pages/onboarding/confetti.js
+++ b/src/pages/onboarding/confetti.js
@@ -1,0 +1,34 @@
+const CONFETTI_EMOJIS = ["🎉", "🎊", "✨", "🥳", "⭐", "💫", "🪄", "🍾"];
+const CONFETTI_COUNT = 36;
+const CONFETTI_MAX_DURATION_MS = 2000;
+const CONFETTI_MAX_DELAY_MS = 200;
+const CONFETTI_LIFE_MS = CONFETTI_MAX_DURATION_MS + CONFETTI_MAX_DELAY_MS + 100;
+
+export function fireConfetti(host = document.body) {
+  const layer = document.createElement("div");
+  layer.className = "ob-confetti-layer";
+
+  for (let i = 0; i < CONFETTI_COUNT; i++) {
+    const piece = document.createElement("span");
+    piece.className = "ob-confetti";
+    piece.textContent = CONFETTI_EMOJIS[i % CONFETTI_EMOJIS.length];
+    const angle = Math.random() * Math.PI * 2;
+    const distance = 180 + Math.random() * 280;
+    const dx = Math.cos(angle) * distance;
+    const dy = Math.sin(angle) * distance - 80;
+    const rot = (Math.random() * 720 - 360).toFixed(0);
+    const duration = 1200 + Math.random() * 800;
+    const delay = Math.random() * CONFETTI_MAX_DELAY_MS;
+    const size = 18 + Math.random() * 14;
+    piece.style.setProperty("--dx", `${dx.toFixed(0)}px`);
+    piece.style.setProperty("--dy", `${dy.toFixed(0)}px`);
+    piece.style.setProperty("--rot", `${rot}deg`);
+    piece.style.fontSize = `${size.toFixed(0)}px`;
+    piece.style.animationDuration = `${duration}ms`;
+    piece.style.animationDelay = `${delay}ms`;
+    layer.appendChild(piece);
+  }
+
+  host.appendChild(layer);
+  setTimeout(() => layer.remove(), CONFETTI_LIFE_MS);
+}

--- a/src/pages/onboarding/decide-action.js
+++ b/src/pages/onboarding/decide-action.js
@@ -1,0 +1,20 @@
+export function decideAction({ action, state }) {
+  switch (action) {
+    case "next":
+      if (state.isLast()) return { effect: "none" };
+      return { effect: "advance", persist: true };
+    case "skip":
+      if (state.isLast()) return { effect: "none" };
+      return { effect: "advance", persist: false };
+    case "back":
+      if (state.isFirst()) return { effect: "none" };
+      return { effect: "retreat" };
+    case "skip-all":
+      return { effect: "close" };
+    case "finish":
+      if (!state.isLast()) return { effect: "none" };
+      return { effect: "close" };
+    default:
+      return { effect: "none" };
+  }
+}

--- a/src/pages/onboarding/dom-helpers.js
+++ b/src/pages/onboarding/dom-helpers.js
@@ -1,0 +1,18 @@
+export function clearChildren(node) {
+  while (node.firstChild) node.removeChild(node.firstChild);
+}
+
+export function createEl(tag, attrs = {}, ...children) {
+  const node = document.createElement(tag);
+  for (const [k, v] of Object.entries(attrs)) {
+    if (k === "class") node.className = v;
+    else if (k === "dataset") Object.assign(node.dataset, v);
+    else if (k.startsWith("aria") || k === "role" || k === "for") node.setAttribute(k, v);
+    else node[k] = v;
+  }
+  for (const c of children) {
+    if (c == null) continue;
+    node.appendChild(typeof c === "string" ? document.createTextNode(c) : c);
+  }
+  return node;
+}

--- a/src/pages/onboarding/onboarding.css
+++ b/src/pages/onboarding/onboarding.css
@@ -1,0 +1,545 @@
+/* Wizard-specific styles. Layered on top of pages.css (which already imports
+ * popup.css for theme tokens: --primary, --card, --text, --border, --shadow). */
+
+.wizard-root {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+/* Visually hidden but available to assistive tech */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.wizard-step h2:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 4px;
+  border-radius: 4px;
+}
+
+/* Header: skip-all link sits to the right of the title row */
+.wizard-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.wizard-title-block {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 12px;
+  text-align: left;
+}
+
+.wizard-title-block .page-logo {
+  width: 36px;
+  height: 36px;
+  margin: 0;
+}
+
+.wizard-title-block .page-title {
+  font-size: 18px;
+  margin: 0;
+}
+
+.skip-all-link {
+  background: none;
+  border: none;
+  font-size: 13px;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 6px 10px;
+  border-radius: 6px;
+  transition: background 0.15s, color 0.15s;
+}
+
+.skip-all-link:hover {
+  background: var(--border);
+  color: var(--text);
+}
+
+.skip-all-link:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+[data-current-step="done"] .skip-all-link {
+  visibility: hidden;
+}
+
+/* Progress bar */
+.wizard-progress {
+  height: 6px;
+  background: var(--border);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.wizard-progress-fill {
+  height: 100%;
+  background: var(--primary);
+  width: 16.66%;
+  transition: width 0.25s ease-out;
+}
+
+/* Stage holds all step sections; only .is-active is visible */
+.wizard-stage {
+  position: relative;
+  min-height: 320px;
+}
+
+.wizard-step {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  opacity: 0;
+  transform: translateX(24px);
+  transition: opacity 0.2s ease-out, transform 0.2s ease-out;
+  pointer-events: none;
+}
+
+.wizard-step.is-active {
+  position: relative;
+  opacity: 1;
+  transform: none;
+  pointer-events: auto;
+}
+
+.wizard-stage.is-leaving-forward .wizard-step.is-active {
+  opacity: 0;
+  transform: translateX(-24px);
+}
+
+.wizard-stage.is-leaving-back .wizard-step.is-active {
+  opacity: 0;
+  transform: translateX(24px);
+}
+
+.wizard-step h2 {
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.wizard-step [data-step-body] {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.wizard-step p {
+  font-size: 14px;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+/* Per-step nav row sits at the bottom of every step */
+.wizard-nav {
+  margin-top: auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  padding-top: 12px;
+}
+
+.wizard-nav-spacer {
+  flex: 1;
+}
+
+.btn-ghost {
+  background: none;
+  border: 1px solid transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 14px;
+  padding: 9px 16px;
+  border-radius: 6px;
+  font-weight: 500;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.btn-ghost:hover {
+  background: var(--border);
+  color: var(--text);
+}
+
+/* Outline variant - used for Back (secondary action with weight) */
+.btn-outline {
+  background: var(--card);
+  border: 1px solid var(--border);
+  color: var(--text);
+  cursor: pointer;
+  font-size: 14px;
+  padding: 9px 16px;
+  border-radius: 6px;
+  font-weight: 500;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.btn-outline:hover {
+  background: var(--card-elevated);
+  border-color: var(--secondary);
+}
+
+.btn-outline:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+.btn-ghost:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.btn-ghost:focus-visible,
+.btn-large:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+/* Radio + checkbox card grids (steps 2-4) */
+.ob-radio-grid,
+.ob-checkbox-grid {
+  display: grid;
+  gap: 8px;
+}
+
+.ob-radio-grid {
+  grid-template-columns: 1fr 1fr 1fr;
+}
+
+.ob-checkbox-grid {
+  grid-template-columns: 1fr 1fr;
+}
+
+.ob-radio-card,
+.ob-checkbox-card {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  cursor: pointer;
+  background: var(--card-elevated);
+  transition: border-color 0.15s, background 0.15s;
+  font-size: 13px;
+  color: var(--text);
+}
+
+.ob-radio-card:hover,
+.ob-checkbox-card:hover {
+  border-color: var(--secondary);
+}
+
+.ob-radio-card input,
+.ob-checkbox-card input {
+  accent-color: var(--primary);
+  flex-shrink: 0;
+}
+
+.ob-radio-card-stacked {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+}
+
+.ob-radio-card:has(input:checked),
+.ob-checkbox-card:has(input:checked) {
+  border-color: var(--primary);
+  background: var(--card);
+  box-shadow: 0 0 0 3px var(--ring);
+}
+
+.ob-radio-title {
+  font-weight: 600;
+}
+
+.ob-radio-desc {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+/* Notifications toggle row */
+.ob-toggle-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--card-elevated);
+  cursor: pointer;
+  font-size: 14px;
+  color: var(--text);
+}
+
+.ob-toggle-row input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--primary);
+}
+
+/* Done step: center the badge + heading + subtitle hero block */
+.wizard-step[data-step-id="done"] > .ob-done-badge,
+.wizard-step[data-step-id="done"] > h2,
+.wizard-step[data-step-id="done"] > p {
+  align-self: center;
+  text-align: center;
+}
+
+.wizard-step[data-step-id="done"] > h2 {
+  margin-bottom: -8px;
+}
+
+.wizard-step[data-step-id="done"] > p {
+  margin-bottom: 4px;
+}
+
+.ob-done-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: rgba(5, 150, 105, 0.12);
+  color: var(--success);
+}
+
+[data-theme="dark"] .ob-done-badge {
+  background: rgba(110, 231, 183, 0.15);
+}
+
+/* Done step: pin-to-toolbar reminder card */
+.ob-pin-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px 16px;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.08), rgba(124, 58, 237, 0.08));
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  position: relative;
+}
+
+[data-theme="dark"] .ob-pin-card {
+  background: linear-gradient(135deg, rgba(129, 140, 248, 0.12), rgba(167, 139, 250, 0.12));
+}
+
+.ob-pin-card:not(.is-pinned) .ob-pin-icon {
+  animation: ob-pin-pulse 2.4s ease-out infinite;
+}
+
+@keyframes ob-pin-pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(99, 102, 241, 0.45);
+  }
+  70% {
+    box-shadow: 0 0 0 10px rgba(99, 102, 241, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(99, 102, 241, 0);
+  }
+}
+
+.ob-pin-card.is-pinned {
+  background: linear-gradient(135deg, rgba(5, 150, 105, 0.1), rgba(110, 231, 183, 0.12));
+  border-color: rgba(5, 150, 105, 0.3);
+}
+
+.ob-pin-card.is-pinned .ob-pin-icon {
+  background: var(--success);
+}
+
+.ob-pin-card.just-pinned {
+  animation: ob-pin-pop 0.5s ease-out;
+}
+
+@keyframes ob-pin-pop {
+  0% { transform: scale(1); }
+  40% { transform: scale(1.04); }
+  100% { transform: scale(1); }
+}
+
+/* Confetti layer + emojis */
+.ob-confetti-layer {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: 9999;
+}
+
+.ob-confetti {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  display: inline-block;
+  will-change: transform, opacity;
+  animation-name: ob-confetti-fly;
+  animation-timing-function: cubic-bezier(0.16, 0.84, 0.44, 1);
+  animation-fill-mode: forwards;
+  opacity: 1;
+}
+
+@keyframes ob-confetti-fly {
+  0% {
+    transform: translate(-50%, -50%) rotate(0deg) scale(0.6);
+    opacity: 0;
+  }
+  15% {
+    opacity: 1;
+  }
+  100% {
+    transform: translate(calc(-50% + var(--dx)), calc(-50% + var(--dy))) rotate(var(--rot)) scale(1);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ob-confetti-layer { display: none; }
+  .ob-pin-card.just-pinned { animation: none; }
+  .ob-pin-card:not(.is-pinned) .ob-pin-icon { animation: none; }
+}
+
+.ob-pin-icon {
+  flex-shrink: 0;
+}
+
+.ob-pin-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.ob-pin-text strong {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.ob-pin-text p {
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
+/* Done step summary list */
+.ob-summary {
+  display: flex;
+  flex-direction: column;
+  padding: 4px 18px;
+  background: var(--card-elevated);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  margin: 0;
+}
+
+.ob-summary-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.ob-summary-row:last-child {
+  border-bottom: none;
+}
+
+.ob-summary-row dt {
+  flex: 1;
+  font-size: 13px;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.ob-summary-row dd {
+  font-size: 13px;
+  color: var(--text);
+  font-weight: 600;
+  margin: 0;
+}
+
+.ob-summary-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  color: var(--primary);
+  opacity: 0.7;
+  flex-shrink: 0;
+}
+
+.ob-done-actions {
+  margin-top: 4px;
+}
+
+.ob-open-settings {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.ob-open-settings .ob-summary-icon {
+  opacity: 1;
+  color: var(--primary);
+}
+
+.ob-shortcut-hint {
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--text-muted);
+  padding: 8px 12px;
+  background: var(--card-elevated);
+  border-radius: 6px;
+  border-left: 3px solid var(--primary);
+}
+
+.ob-shortcut-hint kbd {
+  display: inline-block;
+  padding: 1px 6px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  font-family: ui-monospace, monospace;
+  font-size: 11px;
+  color: var(--text);
+}
+
+.hint {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+@media (max-width: 480px) {
+  .ob-radio-grid,
+  .ob-checkbox-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .wizard-step,
+  .wizard-progress-fill {
+    transition: none !important;
+  }
+  .wizard-step:not(.is-active) {
+    transform: none;
+  }
+}

--- a/src/pages/onboarding/persist.js
+++ b/src/pages/onboarding/persist.js
@@ -1,0 +1,29 @@
+import { POWER_MODE_NAME_KEY } from "../../shared/constants.js";
+import { getSettings, saveSettings } from "../../shared/storage.js";
+
+const ALLOWED_POWER_MODES = new Set(Object.keys(POWER_MODE_NAME_KEY));
+
+export async function persistAutoUnload(value) {
+  const minutes = Number(value);
+  if (!Number.isFinite(minutes) || minutes <= 0) return;
+  const current = await getSettings();
+  await saveSettings({ ...current, unloadDelayMinutes: minutes });
+}
+
+export async function persistWhitelist(domains) {
+  if (!Array.isArray(domains)) return;
+  const cleaned = [...new Set(domains.map((d) => String(d).trim().toLowerCase()).filter(Boolean))];
+  const current = await getSettings();
+  await saveSettings({ ...current, whitelist: cleaned });
+}
+
+export async function persistPowerMode(mode) {
+  if (!ALLOWED_POWER_MODES.has(mode)) return;
+  const current = await getSettings();
+  await saveSettings({ ...current, powerMode: mode });
+}
+
+export async function persistNotifications(enabled) {
+  const current = await getSettings();
+  await saveSettings({ ...current, notifyOnAutoUnload: !!enabled });
+}

--- a/src/pages/onboarding/pin-watcher.js
+++ b/src/pages/onboarding/pin-watcher.js
@@ -1,0 +1,73 @@
+// Detects when the user pins the extension during the Done step.
+// Chrome's chrome.action.getUserSettings() returns { isOnToolbar: boolean }.
+// We poll because there is no event for "user toggled pin in the puzzle menu".
+
+const POLL_INTERVAL_MS = 1000;
+
+export async function getPinStatus() {
+  if (!chrome.action?.getUserSettings) return null;
+  try {
+    const settings = await chrome.action.getUserSettings();
+    return !!settings?.isOnToolbar;
+  } catch {
+    return null;
+  }
+}
+
+export function watchUntilPinned(onPinned) {
+  let stopped = false;
+  let timer = null;
+
+  async function tick() {
+    if (stopped) return;
+    const pinned = await getPinStatus();
+    if (pinned) {
+      stopped = true;
+      onPinned();
+      return;
+    }
+    timer = setTimeout(tick, POLL_INTERVAL_MS);
+  }
+
+  tick();
+
+  return () => {
+    stopped = true;
+    if (timer) clearTimeout(timer);
+  };
+}
+
+const CONFETTI_EMOJIS = ["🎉", "🎊", "✨", "🥳", "⭐", "💫", "🪄", "🍾"];
+const CONFETTI_COUNT = 36;
+const CONFETTI_MAX_DURATION_MS = 2000;
+const CONFETTI_MAX_DELAY_MS = 200;
+const CONFETTI_LIFE_MS = CONFETTI_MAX_DURATION_MS + CONFETTI_MAX_DELAY_MS + 100;
+
+export function fireConfetti(host = document.body) {
+  const layer = document.createElement("div");
+  layer.className = "ob-confetti-layer";
+
+  for (let i = 0; i < CONFETTI_COUNT; i++) {
+    const piece = document.createElement("span");
+    piece.className = "ob-confetti";
+    piece.textContent = CONFETTI_EMOJIS[i % CONFETTI_EMOJIS.length];
+    const angle = Math.random() * Math.PI * 2;
+    const distance = 180 + Math.random() * 280;
+    const dx = Math.cos(angle) * distance;
+    const dy = Math.sin(angle) * distance - 80;
+    const rot = (Math.random() * 720 - 360).toFixed(0);
+    const duration = 1200 + Math.random() * 800;
+    const delay = Math.random() * CONFETTI_MAX_DELAY_MS;
+    const size = 18 + Math.random() * 14;
+    piece.style.setProperty("--dx", `${dx.toFixed(0)}px`);
+    piece.style.setProperty("--dy", `${dy.toFixed(0)}px`);
+    piece.style.setProperty("--rot", `${rot}deg`);
+    piece.style.fontSize = `${size.toFixed(0)}px`;
+    piece.style.animationDuration = `${duration}ms`;
+    piece.style.animationDelay = `${delay}ms`;
+    layer.appendChild(piece);
+  }
+
+  host.appendChild(layer);
+  setTimeout(() => layer.remove(), CONFETTI_LIFE_MS);
+}

--- a/src/pages/onboarding/pin-watcher.js
+++ b/src/pages/onboarding/pin-watcher.js
@@ -14,19 +14,20 @@ export async function getPinStatus() {
   }
 }
 
-export function watchUntilPinned(onPinned) {
+export function watchUntilPinned(onPinned, intervalMs = POLL_INTERVAL_MS) {
   let stopped = false;
   let timer = null;
 
   async function tick() {
     if (stopped) return;
     const pinned = await getPinStatus();
+    if (stopped) return;
     if (pinned) {
       stopped = true;
       onPinned();
       return;
     }
-    timer = setTimeout(tick, POLL_INTERVAL_MS);
+    timer = setTimeout(tick, intervalMs);
   }
 
   tick();
@@ -35,39 +36,4 @@ export function watchUntilPinned(onPinned) {
     stopped = true;
     if (timer) clearTimeout(timer);
   };
-}
-
-const CONFETTI_EMOJIS = ["🎉", "🎊", "✨", "🥳", "⭐", "💫", "🪄", "🍾"];
-const CONFETTI_COUNT = 36;
-const CONFETTI_MAX_DURATION_MS = 2000;
-const CONFETTI_MAX_DELAY_MS = 200;
-const CONFETTI_LIFE_MS = CONFETTI_MAX_DURATION_MS + CONFETTI_MAX_DELAY_MS + 100;
-
-export function fireConfetti(host = document.body) {
-  const layer = document.createElement("div");
-  layer.className = "ob-confetti-layer";
-
-  for (let i = 0; i < CONFETTI_COUNT; i++) {
-    const piece = document.createElement("span");
-    piece.className = "ob-confetti";
-    piece.textContent = CONFETTI_EMOJIS[i % CONFETTI_EMOJIS.length];
-    const angle = Math.random() * Math.PI * 2;
-    const distance = 180 + Math.random() * 280;
-    const dx = Math.cos(angle) * distance;
-    const dy = Math.sin(angle) * distance - 80;
-    const rot = (Math.random() * 720 - 360).toFixed(0);
-    const duration = 1200 + Math.random() * 800;
-    const delay = Math.random() * CONFETTI_MAX_DELAY_MS;
-    const size = 18 + Math.random() * 14;
-    piece.style.setProperty("--dx", `${dx.toFixed(0)}px`);
-    piece.style.setProperty("--dy", `${dy.toFixed(0)}px`);
-    piece.style.setProperty("--rot", `${rot}deg`);
-    piece.style.fontSize = `${size.toFixed(0)}px`;
-    piece.style.animationDuration = `${duration}ms`;
-    piece.style.animationDelay = `${delay}ms`;
-    layer.appendChild(piece);
-  }
-
-  host.appendChild(layer);
-  setTimeout(() => layer.remove(), CONFETTI_LIFE_MS);
 }

--- a/src/pages/onboarding/render-done.js
+++ b/src/pages/onboarding/render-done.js
@@ -1,8 +1,9 @@
 import { POWER_MODE_NAME_KEY, WHITELIST_SUGGESTIONS } from "../../shared/constants.js";
 import { t } from "../../shared/i18n.js";
 import { icon } from "../../shared/icons.js";
+import { fireConfetti } from "./confetti.js";
 import { clearChildren, createEl } from "./dom-helpers.js";
-import { fireConfetti, getPinStatus, watchUntilPinned } from "./pin-watcher.js";
+import { getPinStatus, watchUntilPinned } from "./pin-watcher.js";
 
 const SUMMARY_ROWS = [
   ["clock", "obDoneSummaryDelay"],

--- a/src/pages/onboarding/render-done.js
+++ b/src/pages/onboarding/render-done.js
@@ -1,0 +1,117 @@
+import { POWER_MODE_NAME_KEY, WHITELIST_SUGGESTIONS } from "../../shared/constants.js";
+import { t } from "../../shared/i18n.js";
+import { icon } from "../../shared/icons.js";
+import { clearChildren, createEl } from "./dom-helpers.js";
+import { fireConfetti, getPinStatus, watchUntilPinned } from "./pin-watcher.js";
+
+const SUMMARY_ROWS = [
+  ["clock", "obDoneSummaryDelay"],
+  ["shield", "obDoneSummaryWhitelist"],
+  ["zap", "obDoneSummaryPowerMode"],
+  ["volume", "obDoneSummaryNotifs"],
+];
+
+const SHORTCUT_MARKER = "{{KBD}}";
+const SHORTCUT_KEYS = "Alt+Shift+D";
+
+function delayText(minutes) {
+  return minutes >= 60 && minutes % 60 === 0
+    ? t("obHours", [String(minutes / 60)])
+    : t("obMinutes", [String(minutes)]);
+}
+
+function openSettings() {
+  if (chrome.runtime?.openOptionsPage) {
+    chrome.runtime.openOptionsPage();
+  } else {
+    chrome.tabs.create({ url: chrome.runtime.getURL("src/options/options.html") });
+  }
+}
+
+function iconEl(name, size = 16) {
+  const span = createEl("span", { class: "ob-summary-icon" });
+  span.innerHTML = icon(name, size);
+  return span;
+}
+
+let stopWatching = null;
+
+function buildPinCard(pinned) {
+  const card = createEl("div", { class: `ob-pin-card${pinned ? " is-pinned" : ""}` });
+  const iconWrap = createEl("span", { class: "feature-icon ob-pin-icon" });
+  iconWrap.innerHTML = icon(pinned ? "check" : "pin", 20);
+  const text = createEl("div", { class: "ob-pin-text" });
+  text.appendChild(createEl("strong", {}, t(pinned ? "obPinnedTitle" : "obPinTitle")));
+  text.appendChild(createEl("p", {}, t(pinned ? "obPinnedDesc" : "obPinDesc")));
+  card.appendChild(iconWrap);
+  card.appendChild(text);
+  return card;
+}
+
+export function renderDone(bodyEl, settings) {
+  clearChildren(bodyEl);
+  if (stopWatching) {
+    stopWatching();
+    stopWatching = null;
+  }
+
+  const minutes = Number(settings.unloadDelayMinutes) || 30;
+  const knownPicks = (settings.whitelist || []).filter((d) => WHITELIST_SUGGESTIONS.includes(d));
+  const pmKey = POWER_MODE_NAME_KEY[settings.powerMode] ?? POWER_MODE_NAME_KEY.normal;
+
+  const values = {
+    obDoneSummaryDelay: delayText(minutes),
+    obDoneSummaryWhitelist: t("obDoneSummaryWhitelistN", [String(knownPicks.length)]),
+    obDoneSummaryPowerMode: t(pmKey),
+    obDoneSummaryNotifs: t(settings.notifyOnAutoUnload ? "obOnState" : "obOffState"),
+  };
+
+  const pinHost = createEl("div", { class: "ob-pin-host" });
+  pinHost.appendChild(buildPinCard(false));
+  bodyEl.appendChild(pinHost);
+
+  getPinStatus().then((initiallyPinned) => {
+    if (!pinHost.isConnected) return;
+    if (initiallyPinned === true) {
+      pinHost.replaceChildren(buildPinCard(true));
+      return;
+    }
+    if (initiallyPinned === null) return;
+    stopWatching = watchUntilPinned(() => {
+      if (!pinHost.isConnected) return;
+      const pinnedCard = buildPinCard(true);
+      pinnedCard.classList.add("just-pinned");
+      pinHost.replaceChildren(pinnedCard);
+      fireConfetti();
+    });
+  });
+
+  const list = createEl("dl", { class: "ob-summary" });
+  for (const [iconName, labelKey] of SUMMARY_ROWS) {
+    list.appendChild(
+      createEl(
+        "div",
+        { class: "ob-summary-row" },
+        iconEl(iconName),
+        createEl("dt", {}, t(labelKey)),
+        createEl("dd", {}, values[labelKey]),
+      ),
+    );
+  }
+  bodyEl.appendChild(list);
+
+  const link = createEl("button", { type: "button", class: "btn-outline ob-open-settings" });
+  link.appendChild(iconEl("sliders", 14));
+  link.appendChild(createEl("span", {}, t("obDoneOpenSettings")));
+  link.addEventListener("click", openSettings);
+  bodyEl.appendChild(createEl("div", { class: "ob-done-actions" }, link));
+
+  const tip = createEl("p", { class: "ob-shortcut-hint" });
+  const [before, after = ""] = t("obDoneShortcutsHint", [SHORTCUT_MARKER]).split(SHORTCUT_MARKER);
+  tip.appendChild(document.createTextNode(before));
+  tip.appendChild(createEl("kbd", {}, SHORTCUT_KEYS));
+  tip.appendChild(document.createTextNode(after));
+  bodyEl.appendChild(tip);
+
+  return () => undefined;
+}

--- a/src/pages/onboarding/state.js
+++ b/src/pages/onboarding/state.js
@@ -1,0 +1,30 @@
+export function createState(total) {
+  if (!Number.isInteger(total) || total < 1) {
+    throw new Error("createState: total must be a positive integer");
+  }
+
+  let stepIndex = 0;
+
+  return {
+    get stepIndex() {
+      return stepIndex;
+    },
+    get total() {
+      return total;
+    },
+    isFirst() {
+      return stepIndex === 0;
+    },
+    isLast() {
+      return stepIndex === total - 1;
+    },
+    advance() {
+      if (stepIndex < total - 1) stepIndex += 1;
+      return stepIndex;
+    },
+    retreat() {
+      if (stepIndex > 0) stepIndex -= 1;
+      return stepIndex;
+    },
+  };
+}

--- a/src/pages/onboarding/step-renderers.js
+++ b/src/pages/onboarding/step-renderers.js
@@ -1,0 +1,121 @@
+import {
+  POWER_MODE_DESC_KEY,
+  POWER_MODE_NAME_KEY,
+  WHITELIST_SUGGESTIONS,
+} from "../../shared/constants.js";
+import { t } from "../../shared/i18n.js";
+import { clearChildren, createEl } from "./dom-helpers.js";
+
+const POWER_MODES = Object.keys(POWER_MODE_NAME_KEY);
+const AUTO_UNLOAD_OPTIONS = [30, 60, 120];
+
+export function renderWelcome() {
+  return () => undefined;
+}
+
+export function renderAutoUnload(bodyEl, settings) {
+  clearChildren(bodyEl);
+  const current = AUTO_UNLOAD_OPTIONS.includes(settings.unloadDelayMinutes)
+    ? settings.unloadDelayMinutes
+    : 30;
+  const grid = createEl("div", { class: "ob-radio-grid" });
+  for (const minutes of AUTO_UNLOAD_OPTIONS) {
+    const id = `ob-auto-${minutes}`;
+    const labelKey = `obAutoUnloadOpt${minutes}`;
+    const input = createEl("input", {
+      type: "radio",
+      name: "ob-auto-unload",
+      value: String(minutes),
+      id,
+      checked: minutes === current,
+    });
+    grid.appendChild(
+      createEl(
+        "label",
+        { class: "ob-radio-card", for: id },
+        input,
+        createEl("span", { class: "ob-radio-label" }, t(labelKey)),
+      ),
+    );
+  }
+  bodyEl.appendChild(grid);
+  return () => {
+    const checked = bodyEl.querySelector('input[name="ob-auto-unload"]:checked');
+    return checked ? Number(checked.value) : current;
+  };
+}
+
+export function renderWhitelist(bodyEl, settings) {
+  clearChildren(bodyEl);
+  const existing = new Set((settings.whitelist || []).map((s) => String(s).toLowerCase()));
+  const grid = createEl("div", { class: "ob-checkbox-grid" });
+  for (const domain of WHITELIST_SUGGESTIONS) {
+    const id = `ob-wl-${domain}`;
+    const input = createEl("input", {
+      type: "checkbox",
+      value: domain,
+      id,
+      checked: existing.has(domain),
+    });
+    grid.appendChild(
+      createEl(
+        "label",
+        { class: "ob-checkbox-card", for: id },
+        input,
+        createEl("span", { class: "ob-checkbox-label" }, domain),
+      ),
+    );
+  }
+  bodyEl.appendChild(grid);
+  return () =>
+    Array.from(bodyEl.querySelectorAll("input[type=checkbox]:checked")).map((b) => b.value);
+}
+
+export function renderPowerMode(bodyEl, settings) {
+  clearChildren(bodyEl);
+  const current = POWER_MODES.includes(settings.powerMode) ? settings.powerMode : "normal";
+  const grid = createEl("div", { class: "ob-radio-grid" });
+  for (const mode of POWER_MODES) {
+    const id = `ob-pm-${mode}`;
+    const input = createEl("input", {
+      type: "radio",
+      name: "ob-power-mode",
+      value: mode,
+      id,
+      checked: mode === current,
+    });
+    grid.appendChild(
+      createEl(
+        "label",
+        { class: "ob-radio-card ob-radio-card-stacked", for: id },
+        input,
+        createEl("span", { class: "ob-radio-title" }, t(POWER_MODE_NAME_KEY[mode])),
+        createEl("span", { class: "ob-radio-desc" }, t(POWER_MODE_DESC_KEY[mode])),
+      ),
+    );
+  }
+  bodyEl.appendChild(grid);
+  return () => {
+    const checked = bodyEl.querySelector('input[name="ob-power-mode"]:checked');
+    return checked ? checked.value : current;
+  };
+}
+
+export function renderNotifications(bodyEl, settings) {
+  clearChildren(bodyEl);
+  const id = "ob-notif-toggle";
+  const input = createEl("input", {
+    type: "checkbox",
+    id,
+    checked: !!settings.notifyOnAutoUnload,
+  });
+  bodyEl.appendChild(
+    createEl(
+      "label",
+      { class: "ob-toggle-row", for: id },
+      input,
+      createEl("span", { class: "ob-toggle-label" }, t("obNotificationsToggle")),
+    ),
+  );
+  return () => bodyEl.querySelector(`#${id}`).checked;
+}

--- a/src/pages/onboarding/steps.js
+++ b/src/pages/onboarding/steps.js
@@ -1,0 +1,45 @@
+import {
+  persistAutoUnload,
+  persistNotifications,
+  persistPowerMode,
+  persistWhitelist,
+} from "./persist.js";
+import { renderDone } from "./render-done.js";
+import {
+  renderAutoUnload,
+  renderNotifications,
+  renderPowerMode,
+  renderWelcome,
+  renderWhitelist,
+} from "./step-renderers.js";
+
+const noop = () => undefined;
+
+export const STEPS = [
+  { id: "welcome", titleKey: "obWelcomeTitle", render: renderWelcome, persist: noop },
+  {
+    id: "auto-unload",
+    titleKey: "obAutoUnloadTitle",
+    render: renderAutoUnload,
+    persist: persistAutoUnload,
+  },
+  {
+    id: "whitelist",
+    titleKey: "obWhitelistTitle",
+    render: renderWhitelist,
+    persist: persistWhitelist,
+  },
+  {
+    id: "power-mode",
+    titleKey: "obPowerModeTitle",
+    render: renderPowerMode,
+    persist: persistPowerMode,
+  },
+  {
+    id: "notifications",
+    titleKey: "obNotificationsTitle",
+    render: renderNotifications,
+    persist: persistNotifications,
+  },
+  { id: "done", titleKey: "obDoneTitle", render: renderDone, persist: noop },
+];

--- a/src/pages/onboarding/wizard.js
+++ b/src/pages/onboarding/wizard.js
@@ -1,0 +1,126 @@
+import { t } from "../../shared/i18n.js";
+import { getSettings } from "../../shared/storage.js";
+import { decideAction } from "./decide-action.js";
+import { createState } from "./state.js";
+import { STEPS } from "./steps.js";
+
+const TRANSITION_MS = 200;
+const TRANSITION_BUFFER_MS = 50;
+
+export { decideAction };
+
+export function mountWizard(rootEl, deps = {}) {
+  if (!rootEl) return null;
+
+  const closeWindow = deps.closeWindow ?? (() => window.close());
+  const loadSettings = deps.loadSettings ?? getSettings;
+
+  const state = createState(STEPS.length);
+  const stage = rootEl.querySelector(".wizard-stage");
+  const progressFill = rootEl.querySelector(".wizard-progress-fill");
+  const progressBar = rootEl.querySelector(".wizard-progress");
+  const announcer = rootEl.querySelector("#wizard-announcer");
+  const sections = Array.from(rootEl.querySelectorAll(".wizard-step"));
+  const reducedMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+
+  let valueGetter = null;
+
+  function activeSection() {
+    return sections[state.stepIndex] ?? null;
+  }
+
+  async function renderStepBody() {
+    const sec = activeSection();
+    const step = STEPS[state.stepIndex];
+    if (!sec || !step) return;
+    const slot = sec.querySelector("[data-step-body]");
+    if (!slot) {
+      valueGetter = null;
+      return;
+    }
+    const settings = await loadSettings();
+    valueGetter = step.render(slot, settings) ?? null;
+  }
+
+  function focusActiveHeading() {
+    const heading = activeSection()?.querySelector("h2");
+    if (!heading) return;
+    if (!heading.hasAttribute("tabindex")) heading.setAttribute("tabindex", "-1");
+    heading.focus({ preventScroll: false });
+  }
+
+  function applyVisibility() {
+    sections.forEach((sec, i) => {
+      const isActive = i === state.stepIndex;
+      sec.classList.toggle("is-active", isActive);
+      if (isActive) sec.removeAttribute("inert");
+      else sec.setAttribute("inert", "");
+    });
+    rootEl.dataset.currentStep = STEPS[state.stepIndex]?.id ?? "";
+    if (progressFill) {
+      progressFill.style.width = `${((state.stepIndex + 1) / state.total) * 100}%`;
+    }
+    if (progressBar) {
+      progressBar.setAttribute("aria-valuenow", String(state.stepIndex + 1));
+    }
+    if (announcer) {
+      announcer.textContent = t("obProgressLabel", [
+        String(state.stepIndex + 1),
+        String(state.total),
+      ]);
+    }
+  }
+
+  async function swapTo(direction) {
+    if (reducedMotion || !stage) {
+      applyVisibility();
+      await renderStepBody();
+      focusActiveHeading();
+      return;
+    }
+    const leavingClass = direction === "forward" ? "is-leaving-forward" : "is-leaving-back";
+    stage.classList.add(leavingClass);
+    await new Promise((r) => setTimeout(r, TRANSITION_MS + TRANSITION_BUFFER_MS));
+    stage.classList.remove(leavingClass);
+    applyVisibility();
+    await renderStepBody();
+    focusActiveHeading();
+  }
+
+  async function handleAction(action) {
+    const decision = decideAction({ action, state });
+    if (decision.effect === "close") {
+      closeWindow();
+      return;
+    }
+    if (decision.effect === "advance") {
+      const outgoing = STEPS[state.stepIndex];
+      if (decision.persist && valueGetter && outgoing?.persist) {
+        try {
+          await outgoing.persist(valueGetter());
+        } catch (err) {
+          console.error("[wizard] persist failed:", err);
+        }
+      }
+      state.advance();
+      await swapTo("forward");
+      return;
+    }
+    if (decision.effect === "retreat") {
+      state.retreat();
+      await swapTo("back");
+    }
+  }
+
+  rootEl.addEventListener("click", (e) => {
+    const target = e.target.closest("[data-action]");
+    if (!target || !rootEl.contains(target)) return;
+    e.preventDefault();
+    handleAction(target.dataset.action);
+  });
+
+  applyVisibility();
+  renderStepBody();
+
+  return { state, handleAction };
+}

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -50,6 +50,33 @@ export const YOUTUBE_TIMESTAMPS_KEY = "youtube_timestamps";
 // YouTube timestamp max age (7 days in milliseconds)
 export const YOUTUBE_TIMESTAMP_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 
+// Curated whitelist suggestions surfaced by the onboarding wizard step 3.
+// Single source of truth so future surfaces (options "starter pack" button,
+// help docs) reuse the same list.
+export const WHITELIST_SUGGESTIONS = Object.freeze([
+  "gmail.com",
+  "docs.google.com",
+  "github.com",
+  "notion.so",
+  "figma.com",
+  "youtube.com",
+]);
+
+// Maps powerMode setting value to the i18n key that names it. Reuses the
+// existing keys defined in _locales/* (batterySaver / normalMode /
+// performanceMode) so wizard + options page share one set of strings.
+export const POWER_MODE_NAME_KEY = Object.freeze({
+  "battery-saver": "batterySaver",
+  normal: "normalMode",
+  performance: "performanceMode",
+});
+
+export const POWER_MODE_DESC_KEY = Object.freeze({
+  "battery-saver": "batterySaverDesc",
+  normal: "normalModeDesc",
+  performance: "performanceModeDesc",
+});
+
 // Power mode configuration - affects delay and memory thresholds
 export const POWER_MODE_CONFIG = {
   "battery-saver": {

--- a/tests/pages/onboarding-pin-watcher.test.js
+++ b/tests/pages/onboarding-pin-watcher.test.js
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getPinStatus, watchUntilPinned } from "../../src/pages/onboarding/pin-watcher.js";
+
+const ORIGINAL_ACTION = chrome.action;
+
+afterEach(() => {
+  chrome.action = ORIGINAL_ACTION;
+  vi.useRealTimers();
+});
+
+describe("getPinStatus", () => {
+  it("returns true when isOnToolbar is true", async () => {
+    chrome.action = { getUserSettings: vi.fn(() => Promise.resolve({ isOnToolbar: true })) };
+    expect(await getPinStatus()).toBe(true);
+  });
+
+  it("returns false when isOnToolbar is false", async () => {
+    chrome.action = { getUserSettings: vi.fn(() => Promise.resolve({ isOnToolbar: false })) };
+    expect(await getPinStatus()).toBe(false);
+  });
+
+  it("returns null when chrome.action is undefined", async () => {
+    chrome.action = undefined;
+    expect(await getPinStatus()).toBe(null);
+  });
+
+  it("returns null when getUserSettings is missing", async () => {
+    chrome.action = {};
+    expect(await getPinStatus()).toBe(null);
+  });
+
+  it("returns null when getUserSettings rejects", async () => {
+    chrome.action = { getUserSettings: vi.fn(() => Promise.reject(new Error("denied"))) };
+    expect(await getPinStatus()).toBe(null);
+  });
+
+  it("returns false when settings.isOnToolbar is missing", async () => {
+    chrome.action = { getUserSettings: vi.fn(() => Promise.resolve({})) };
+    expect(await getPinStatus()).toBe(false);
+  });
+});
+
+describe("watchUntilPinned", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it("calls onPinned and stops once status becomes true", async () => {
+    let pinned = false;
+    chrome.action = {
+      getUserSettings: vi.fn(() => Promise.resolve({ isOnToolbar: pinned })),
+    };
+
+    const onPinned = vi.fn();
+    watchUntilPinned(onPinned, 50);
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onPinned).not.toHaveBeenCalled();
+
+    pinned = true;
+    await vi.advanceTimersByTimeAsync(50);
+    expect(onPinned).toHaveBeenCalledOnce();
+
+    const callsBefore = chrome.action.getUserSettings.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(200);
+    expect(chrome.action.getUserSettings.mock.calls.length).toBe(callsBefore);
+  });
+
+  it("stop() cancels pending poll without firing onPinned", async () => {
+    chrome.action = {
+      getUserSettings: vi.fn(() => Promise.resolve({ isOnToolbar: false })),
+    };
+    const onPinned = vi.fn();
+    const stop = watchUntilPinned(onPinned, 50);
+
+    await vi.advanceTimersByTimeAsync(0);
+    stop();
+    await vi.advanceTimersByTimeAsync(500);
+    expect(onPinned).not.toHaveBeenCalled();
+  });
+
+  it("does not fire onPinned if pinned status arrives after stop", async () => {
+    let resolveSettings;
+    chrome.action = {
+      getUserSettings: vi.fn(
+        () =>
+          new Promise((resolve) => {
+            resolveSettings = resolve;
+          }),
+      ),
+    };
+    const onPinned = vi.fn();
+    const stop = watchUntilPinned(onPinned, 50);
+
+    stop();
+    resolveSettings({ isOnToolbar: true });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onPinned).not.toHaveBeenCalled();
+  });
+
+  it("multiple stop() calls are safe", async () => {
+    chrome.action = {
+      getUserSettings: vi.fn(() => Promise.resolve({ isOnToolbar: false })),
+    };
+    const stop = watchUntilPinned(vi.fn(), 50);
+    expect(() => {
+      stop();
+      stop();
+      stop();
+    }).not.toThrow();
+  });
+});

--- a/tests/pages/onboarding-wizard-i18n-parity.test.js
+++ b/tests/pages/onboarding-wizard-i18n-parity.test.js
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const en = JSON.parse(readFileSync(resolve("_locales/en/messages.json"), "utf8"));
+const vi = JSON.parse(readFileSync(resolve("_locales/vi/messages.json"), "utf8"));
+
+const obKeys = Object.keys(en).filter((k) => k.startsWith("ob"));
+
+describe("onboarding i18n parity (en + vi)", () => {
+  it("at least 30 ob* keys exist in the en locale", () => {
+    expect(obKeys.length).toBeGreaterThanOrEqual(30);
+  });
+
+  it("every ob* key in en exists in vi with a non-empty message", () => {
+    const missing = obKeys.filter((k) => !vi[k]?.message);
+    expect(missing).toEqual([]);
+  });
+
+  it("every ob* en entry has a non-empty description", () => {
+    const missing = obKeys.filter((k) => !en[k]?.description);
+    expect(missing).toEqual([]);
+  });
+
+  it("no ob* message in either locale uses em or en dash", () => {
+    const offenders = [];
+    for (const k of obKeys) {
+      if (/[–—]/.test(en[k].message)) offenders.push(`en:${k}`);
+      if (vi[k] && /[–—]/.test(vi[k].message)) offenders.push(`vi:${k}`);
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/tests/pages/onboarding-wizard-persist.test.js
+++ b/tests/pages/onboarding-wizard-persist.test.js
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/shared/storage.js", () => ({
+  getSettings: vi.fn(),
+  saveSettings: vi.fn(),
+}));
+
+import { getSettings, saveSettings } from "../../src/shared/storage.js";
+import {
+  persistAutoUnload,
+  persistNotifications,
+  persistPowerMode,
+  persistWhitelist,
+} from "../../src/pages/onboarding/persist.js";
+
+const baseSettings = { unloadDelayMinutes: 30, whitelist: [], powerMode: "normal", notifyOnAutoUnload: false };
+
+beforeEach(() => {
+  getSettings.mockReset();
+  saveSettings.mockReset();
+  getSettings.mockResolvedValue({ ...baseSettings });
+  saveSettings.mockResolvedValue(undefined);
+});
+
+describe("persistAutoUnload", () => {
+  it("writes only the unloadDelayMinutes key", async () => {
+    await persistAutoUnload(60);
+    expect(saveSettings).toHaveBeenCalledTimes(1);
+    expect(saveSettings.mock.calls[0][0]).toEqual({ ...baseSettings, unloadDelayMinutes: 60 });
+  });
+
+  it("ignores invalid values", async () => {
+    await persistAutoUnload("nope");
+    await persistAutoUnload(0);
+    await persistAutoUnload(-5);
+    expect(saveSettings).not.toHaveBeenCalled();
+  });
+});
+
+describe("persistWhitelist", () => {
+  it("dedupes and lowercases domains", async () => {
+    await persistWhitelist(["GitHub.com", "github.com", " Notion.so "]);
+    expect(saveSettings.mock.calls[0][0].whitelist).toEqual(["github.com", "notion.so"]);
+  });
+
+  it("ignores non-array input", async () => {
+    await persistWhitelist("github.com");
+    expect(saveSettings).not.toHaveBeenCalled();
+  });
+
+  it("accepts empty array (replaces with empty list)", async () => {
+    await persistWhitelist([]);
+    expect(saveSettings).toHaveBeenCalledTimes(1);
+    expect(saveSettings.mock.calls[0][0].whitelist).toEqual([]);
+  });
+});
+
+describe("persistPowerMode", () => {
+  it("writes only the powerMode key for allowed values", async () => {
+    await persistPowerMode("battery-saver");
+    expect(saveSettings.mock.calls[0][0]).toEqual({ ...baseSettings, powerMode: "battery-saver" });
+  });
+
+  it("rejects unknown modes", async () => {
+    await persistPowerMode("turbo");
+    expect(saveSettings).not.toHaveBeenCalled();
+  });
+});
+
+describe("persistNotifications", () => {
+  it("coerces truthy/falsy values to boolean", async () => {
+    await persistNotifications(1);
+    expect(saveSettings.mock.calls[0][0].notifyOnAutoUnload).toBe(true);
+    saveSettings.mockClear();
+    await persistNotifications(null);
+    expect(saveSettings.mock.calls[0][0].notifyOnAutoUnload).toBe(false);
+  });
+});

--- a/tests/pages/onboarding-wizard-router.test.js
+++ b/tests/pages/onboarding-wizard-router.test.js
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { decideAction } from "../../src/pages/onboarding/decide-action.js";
+import { createState } from "../../src/pages/onboarding/state.js";
+
+function stateAt(total, idx) {
+  const s = createState(total);
+  for (let i = 0; i < idx; i++) s.advance();
+  return s;
+}
+
+describe("onboarding wizard decideAction", () => {
+  it('next on a non-final step advances and persists', () => {
+    expect(decideAction({ action: "next", state: stateAt(6, 2) })).toEqual({
+      effect: "advance",
+      persist: true,
+    });
+  });
+
+  it('next on the final step is a no-op (Finish handles last)', () => {
+    expect(decideAction({ action: "next", state: stateAt(6, 5) })).toEqual({ effect: "none" });
+  });
+
+  it('skip advances without persisting', () => {
+    expect(decideAction({ action: "skip", state: stateAt(6, 1) })).toEqual({
+      effect: "advance",
+      persist: false,
+    });
+  });
+
+  it('skip on the final step is a no-op', () => {
+    expect(decideAction({ action: "skip", state: stateAt(6, 5) })).toEqual({ effect: "none" });
+  });
+
+  it('back retreats from non-first step', () => {
+    expect(decideAction({ action: "back", state: stateAt(6, 3) })).toEqual({ effect: "retreat" });
+  });
+
+  it('back at step 0 is a no-op', () => {
+    expect(decideAction({ action: "back", state: stateAt(6, 0) })).toEqual({ effect: "none" });
+  });
+
+  it('skip-all closes the window from any step', () => {
+    expect(decideAction({ action: "skip-all", state: stateAt(6, 0) })).toEqual({ effect: "close" });
+    expect(decideAction({ action: "skip-all", state: stateAt(6, 4) })).toEqual({ effect: "close" });
+  });
+
+  it('finish closes only on the last step', () => {
+    expect(decideAction({ action: "finish", state: stateAt(6, 5) })).toEqual({ effect: "close" });
+    expect(decideAction({ action: "finish", state: stateAt(6, 2) })).toEqual({ effect: "none" });
+  });
+
+  it('unknown action is a no-op', () => {
+    expect(decideAction({ action: "explode", state: stateAt(6, 1) })).toEqual({ effect: "none" });
+  });
+});

--- a/tests/pages/onboarding-wizard-state.test.js
+++ b/tests/pages/onboarding-wizard-state.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { createState } from "../../src/pages/onboarding/state.js";
+
+describe("onboarding wizard state", () => {
+  it("initializes at step 0 with given total", () => {
+    const s = createState(6);
+    expect(s.stepIndex).toBe(0);
+    expect(s.total).toBe(6);
+    expect(s.isFirst()).toBe(true);
+    expect(s.isLast()).toBe(false);
+  });
+
+  it("rejects non-positive totals", () => {
+    expect(() => createState(0)).toThrow();
+    expect(() => createState(-1)).toThrow();
+    expect(() => createState(1.5)).toThrow();
+  });
+
+  it("advance increments and clamps at total - 1", () => {
+    const s = createState(3);
+    expect(s.advance()).toBe(1);
+    expect(s.advance()).toBe(2);
+    expect(s.advance()).toBe(2);
+    expect(s.isLast()).toBe(true);
+  });
+
+  it("retreat decrements and clamps at 0", () => {
+    const s = createState(3);
+    s.advance();
+    s.advance();
+    expect(s.retreat()).toBe(1);
+    expect(s.retreat()).toBe(0);
+    expect(s.retreat()).toBe(0);
+    expect(s.isFirst()).toBe(true);
+  });
+
+});

--- a/tests/pages/onboarding-wizard-steps.test.js
+++ b/tests/pages/onboarding-wizard-steps.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { STEPS } from "../../src/pages/onboarding/steps.js";
+
+const EXPECTED_IDS = ["welcome", "auto-unload", "whitelist", "power-mode", "notifications", "done"];
+
+describe("onboarding wizard step config", () => {
+  it("exposes exactly 6 steps in the locked order", () => {
+    expect(STEPS).toHaveLength(6);
+    expect(STEPS.map((s) => s.id)).toEqual(EXPECTED_IDS);
+  });
+
+  it("each step has an id, titleKey, render, and persist", () => {
+    for (const step of STEPS) {
+      expect(typeof step.id).toBe("string");
+      expect(step.id.length).toBeGreaterThan(0);
+      expect(typeof step.titleKey).toBe("string");
+      expect(step.titleKey.startsWith("ob")).toBe(true);
+      expect(typeof step.render).toBe("function");
+      expect(typeof step.persist).toBe("function");
+    }
+  });
+
+  it("welcome and done steps have noop persist (return undefined)", () => {
+    const welcome = STEPS[0];
+    const done = STEPS[STEPS.length - 1];
+    expect(welcome.id).toBe("welcome");
+    expect(done.id).toBe("done");
+    expect(welcome.persist()).toBeUndefined();
+    expect(done.persist()).toBeUndefined();
+  });
+
+  it("step ids are unique", () => {
+    const ids = STEPS.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -68,6 +68,9 @@ global.chrome = {
   scripting: {
     executeScript: vi.fn(() => Promise.resolve([])),
   },
+  action: {
+    getUserSettings: vi.fn(() => Promise.resolve({ isOnToolbar: false })),
+  },
   notifications: {
     create: vi.fn((id, _opts, cb) => {
       if (cb) cb(id);

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -21,6 +21,7 @@ export default defineConfig({
         "src/pages/onboarding/step-renderers.js",
         "src/pages/onboarding/render-done.js",
         "src/pages/onboarding/dom-helpers.js",
+        "src/pages/onboarding/pin-watcher.js",
       ],
       reporter: ["text", "html"],
       reportsDirectory: "./coverage",

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -21,7 +21,7 @@ export default defineConfig({
         "src/pages/onboarding/step-renderers.js",
         "src/pages/onboarding/render-done.js",
         "src/pages/onboarding/dom-helpers.js",
-        "src/pages/onboarding/pin-watcher.js",
+        "src/pages/onboarding/confetti.js",
       ],
       reporter: ["text", "html"],
       reportsDirectory: "./coverage",

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -15,6 +15,12 @@ export default defineConfig({
         // Content scripts: IIFE-loaded against live DOM/window, exercised via
         // browser integration testing rather than node-environment unit tests.
         "src/content/**",
+        // Onboarding wizard: DOM-only renderers and mount glue. Pure logic
+        // (decide-action, state, persist, steps) is covered separately.
+        "src/pages/onboarding/wizard.js",
+        "src/pages/onboarding/step-renderers.js",
+        "src/pages/onboarding/render-done.js",
+        "src/pages/onboarding/dom-helpers.js",
       ],
       reporter: ["text", "html"],
       reportsDirectory: "./coverage",


### PR DESCRIPTION
## Summary

Replace the static install page with a 6-step interactive wizard that lets first-install users tune the most-used settings in-place. Vanilla JS + CSS, no new dependencies, no build step.

**Steps:** welcome → auto-unload timer → whitelist suggestions → power mode → notifications → done.

Each step persists one setting via existing `getSettings`/`saveSettings` on Next click. Skip preserves the existing/default value (no write).

## Highlights

- **Per-step persistence** with skip-friendly semantics; abandonment still leaves a non-empty config
- **Pin-to-toolbar reminder** on Done step: polls `chrome.action.getUserSettings()`, fires emoji confetti when user pins
- **A11y baked in:** aria-live progress announcer, `inert` on non-active steps, focus moves to active heading on every transition
- **CSS-only transitions** (200ms slide+fade); honors `prefers-reduced-motion`
- **i18n en + vi** for ~35 new `ob*` keys; reuses existing `batterySaver` / `normalMode` / `performanceMode` keys
- **\"Run setup again\"** button added to options page
- **No new permissions, no manifest changes, no migration**

## Architecture

```
src/pages/onboarding/
├── wizard.js          # mount + transitions + DOM glue
├── state.js           # state machine (stepIndex, total, advance/retreat)
├── decide-action.js   # pure action dispatcher (next/back/skip/skip-all/finish)
├── steps.js           # step config (id, titleKey, render, persist)
├── step-renderers.js  # 5 step body renderers (welcome..notifications)
├── render-done.js     # Done step + pin card + confetti integration
├── persist.js         # 4 per-key settings writers
├── pin-watcher.js     # chrome.action.getUserSettings poller + confetti
├── dom-helpers.js     # tiny createEl / clearChildren utility
└── onboarding.css     # wizard-only styles
```

Cross-surface constants moved to `src/shared/constants.js`: `WHITELIST_SUGGESTIONS`, `POWER_MODE_NAME_KEY`, `POWER_MODE_DESC_KEY`.

## Tests

31 new unit tests across 5 files:
- State machine (advance/retreat bounds, total clamp)
- Action dispatcher (all 5 actions × first/last/middle steps)
- Persist writers (mocked storage; isolation per key, dedup/lowercase for whitelist, allowed-set check for powerMode)
- Step config invariants (length, ids unique, hooks present, ordering locked)
- i18n parity (every `ob*` key in en exists in vi with non-empty message; en has descriptions; no em/en dashes)

All 613 tests pass; lint clean (biome). Coverage 87.6% lines / 82.6% branches.

## Test plan

- [ ] Load extension on Chrome, force `chrome.runtime.OnInstalledReason.INSTALL` (or remove + reinstall) — wizard opens
- [ ] Step through Welcome → ... → Done with Next, verify each setting persists in chrome.storage.sync
- [ ] Skip individual steps — confirm only non-skipped keys change
- [ ] Skip-all from any step — confirm no writes; window closes
- [ ] On Done step: pin TabRest via puzzle icon → card swaps to green \"Pinned!\" + emoji confetti fires
- [ ] Open options → \"Run setup again\" — wizard reopens
- [ ] DevTools \"Emulate prefers-reduced-motion: reduce\" — no transitions, no confetti
- [ ] Switch Chrome locale to Vietnamese — every wizard string renders in vi
- [ ] Tab through wizard — only active step's controls reachable
- [ ] Screen reader (VoiceOver/NVDA) — announces \"Step X of Y\" on transitions

## Out of scope

- Wizard state persistence across reloads (resumed at step 1 each open)
- jsdom integration tests for DOM-heavy renderers (covered by Approach A: pure logic in `decide-action`/`state`/`persist`/`steps`; DOM glue excluded from coverage)
- Pin watcher backoff / max duration (acceptable for one-shot install flow)