### PR TITLE
docs: refresh README and feature checklist for actual UI ranges

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **tabrest** (2176 symbols, 3410 relationships, 104 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/tabrest/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/tabrest/clusters` | All functional areas |
+| `gitnexus://repo/tabrest/processes` | All execution flows |
+| `gitnexus://repo/tabrest/process/{name}` | Step-by-step execution trace |
+
+## CLI
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+
+<!-- gitnexus:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,3 +76,48 @@ content/
 
 - **No em dash or en dash**: Never use `—` (U+2014) or `–` (U+2013) in any output - prose, code comments, docs, commit messages, PR descriptions, or chat replies. Use a hyphen-minus `-` (with surrounding spaces when used as a sentence break) or rephrase the sentence.
 - **Exception**: UI placeholder values that intentionally render `—` as a "no value" indicator (e.g., `src/popup/popup.html` stat cells, `src/popup/popup.js` `textContent = "—"`). Do not change those.
+
+<!-- gitnexus:start -->
+
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **tabrest** (2176 symbols, 3410 relationships, 104 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Resources
+
+| Resource                                 | Use for                                  |
+| ---------------------------------------- | ---------------------------------------- |
+| `gitnexus://repo/tabrest/context`        | Codebase overview, check index freshness |
+| `gitnexus://repo/tabrest/clusters`       | All functional areas                     |
+| `gitnexus://repo/tabrest/processes`      | All execution flows                      |
+| `gitnexus://repo/tabrest/process/{name}` | Step-by-step execution trace             |
+
+## CLI
+
+| Task                                         | Read this skill file                                        |
+| -------------------------------------------- | ----------------------------------------------------------- |
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md`       |
+| Blast radius / "What breaks if I change X?"  | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?"             | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md`       |
+| Rename / extract / split / refactor          | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md`     |
+| Tools, resources, schema reference           | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md`           |
+| Index, status, clean, wiki CLI commands      | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md`             |
+
+<!-- gitnexus:end -->

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@
 
 ## Features
 
-- **Auto-unload inactive tabs** - Configurable timer (15min to 4hrs)
-- **Memory threshold** - Unload when RAM exceeds 60-90%
+- **Auto-unload inactive tabs** - Configurable timer (5min to 4hrs)
+- **Memory threshold** - Unload when RAM exceeds 60-95%
 - **Per-tab memory limit** - Unload tabs using >100MB-1GB JS heap
 - **Startup unload** - Free memory when browser opens
 - **Manual controls** - Unload current/left/right/other tabs
@@ -42,6 +42,8 @@
 - **Power Mode** - Battery-saver, normal, or performance profiles
 - **Auto-unload notifications** - Get notified when tabs are unloaded
 - **Memory tooltip** - Hover stats to see estimated RAM saved per tab
+- **Onboarding wizard** - Interactive multi-step setup on first run
+- **Opt-in error reporting** - Anonymous crash reports via Sentry (off by default) plus manual bug-report submit
 - **Auto-open changelog** - Opens release notes on minor/major updates
 - **Optional host permissions** - Form protection only requests access when enabled
 - **RAM usage display** - Live RAM % in popup header

--- a/README.vi.md
+++ b/README.vi.md
@@ -20,8 +20,8 @@
 
 ## Tính năng
 
-- **Tự động unload tab không hoạt động** - Hẹn giờ tuỳ chỉnh (15 phút đến 4 giờ)
-- **Ngưỡng bộ nhớ** - Unload khi RAM vượt 60-90%
+- **Tự động unload tab không hoạt động** - Hẹn giờ tuỳ chỉnh (5 phút đến 4 giờ)
+- **Ngưỡng bộ nhớ** - Unload khi RAM vượt 60-95%
 - **Giới hạn bộ nhớ mỗi tab** - Unload tab dùng >100MB-1GB JS heap
 - **Unload khi khởi động** - Giải phóng bộ nhớ khi mở trình duyệt
 - **Điều khiển thủ công** - Unload tab hiện tại/trái/phải/khác
@@ -42,6 +42,8 @@
 - **Power Mode** - Chế độ tiết kiệm pin, bình thường, hoặc hiệu năng cao
 - **Thông báo auto-unload** - Nhận thông báo khi tab được unload
 - **Tooltip bộ nhớ** - Hover thống kê để xem ước tính RAM tiết kiệm trên mỗi tab
+- **Trình hướng dẫn cài đặt** - Wizard nhiều bước tương tác khi mở lần đầu
+- **Báo lỗi tuỳ chọn** - Gửi báo cáo sự cố ẩn danh qua Sentry (mặc định tắt) và form gửi báo lỗi thủ công
 - **Tự mở changelog** - Mở release notes khi cập nhật minor/major
 - **Host permissions tuỳ chọn** - Bảo vệ form chỉ yêu cầu quyền khi bật
 - **Hiển thị RAM** - Phần trăm RAM trực tiếp trên popup

--- a/docs/feature-test-checklist.md
+++ b/docs/feature-test-checklist.md
@@ -31,12 +31,12 @@ Legend: `[ ]` not tested · `[x]` pass · `[!]` fail · `[~]` skip / N/A.
 
 ## 1. Auto-Unload - Inactivity Timer
 
-- [ ] Set `Unload after` = 1 min (Options → Auto-Unload), `Min inactive tabs before discard` = 0.
+- [ ] Set `Unload after` = 5 min (Options → Auto-Unload), `Min inactive tabs before discard` = Disabled.
 - [ ] Open 3 tabs (any non-whitelisted sites). Focus tab A.
-- [ ] Wait 1 min while staying on tab A.
+- [ ] Wait 5 min while staying on tab A.
 - [ ] Tabs B and C are discarded (favicon dimmed, prefix shown). Tab A stays loaded.
 - [ ] Click discarded tab B → reloads instantly, scroll position preserved (if `restoreScrollPosition` on).
-- [ ] Set delay = 0 → auto-unload disabled; verify tabs no longer discard after a minute.
+- [ ] Set delay = Disabled → auto-unload disabled; verify tabs no longer discard after 5 minutes.
 
 ## 2. Auto-Unload - Memory Threshold
 
@@ -68,9 +68,9 @@ Legend: `[ ]` not tested · `[x]` pass · `[!]` fail · `[~]` skip / N/A.
 
 ## 6. Idle-Only Mode
 
-- [ ] Toggle `Only auto-unload when idle` ON; `Idle threshold` = 1 min.
+- [ ] Toggle `Only auto-unload when idle` ON; `Idle threshold` = 2 min.
 - [ ] Keep typing/moving mouse → no auto-unload triggers.
-- [ ] Stop interaction for ≥ 1 min → auto-unload runs on next alarm.
+- [ ] Stop interaction for ≥ 2 min → auto-unload runs on next alarm.
 - [ ] Toggle OFF → auto-unload runs regardless of idle state.
 
 ## 7. Skip When Offline

--- a/docs/vi/feature-test-checklist.md
+++ b/docs/vi/feature-test-checklist.md
@@ -31,12 +31,12 @@ Ký hiệu: `[ ]` chưa test · `[x]` đạt · `[!]` lỗi · `[~]` bỏ qua / 
 
 ## 1. Auto-Unload - Hẹn giờ không hoạt động
 
-- [ ] Đặt `Unload after` = 1 phút (Options → Auto-Unload), `Min inactive tabs before discard` = 0.
+- [ ] Đặt `Unload after` = 5 phút (Options → Auto-Unload), `Min inactive tabs before discard` = Disabled.
 - [ ] Mở 3 tab (site bất kỳ không nằm trong whitelist). Focus tab A.
-- [ ] Đợi 1 phút trên tab A.
+- [ ] Đợi 5 phút trên tab A.
 - [ ] Tab B và C bị discard (favicon mờ, có prefix). Tab A vẫn loaded.
 - [ ] Click tab B đã discard → tải lại tức thì, scroll giữ nguyên (nếu bật `restoreScrollPosition`).
-- [ ] Đặt delay = 0 → tắt auto-unload; xác nhận tab không còn discard sau 1 phút.
+- [ ] Đặt delay = Disabled → tắt auto-unload; xác nhận tab không còn discard sau 5 phút.
 
 ## 2. Auto-Unload - Ngưỡng RAM
 
@@ -68,9 +68,9 @@ Ký hiệu: `[ ]` chưa test · `[x]` đạt · `[!]` lỗi · `[~]` bỏ qua / 
 
 ## 6. Chế độ chỉ chạy khi máy idle
 
-- [ ] Bật `Only auto-unload when idle`; `Idle threshold` = 1 phút.
+- [ ] Bật `Only auto-unload when idle`; `Idle threshold` = 2 phút.
 - [ ] Liên tục gõ phím / di chuột → không có auto-unload.
-- [ ] Ngưng tương tác ≥ 1 phút → auto-unload chạy ở alarm kế tiếp.
+- [ ] Ngưng tương tác ≥ 2 phút → auto-unload chạy ở alarm kế tiếp.
 - [ ] Tắt → auto-unload chạy bất kể idle.
 
 ## 7. Bỏ qua khi offline


### PR DESCRIPTION
## Summary

- README (en/vi): correct timer range to 5min-4hrs, RAM threshold to 60-95%; add bullets for the onboarding wizard and opt-in Sentry error reporting / manual bug report.
- feature-test-checklist (en/vi): align test defaults with current Options UI (delay 5min, idle 2min, "Disabled" label instead of 0).
- chore: add GitNexus code-intelligence block to CLAUDE.md and new AGENTS.md (auto-generated by gitnexus tooling).

## Test plan

- [x] Verify README feature list matches `src/options/options.html` select ranges
- [x] Verify feature-test-checklist instructions match current Options UI labels
- [x] No code changes; CI lint should pass