### PR TITLE
fix(popup): improve dark-mode contrast for tab action icons and timer badge

### DIFF
--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -444,8 +444,9 @@ footer {
   padding: 4px;
   cursor: pointer;
   font-size: 12px;
+  color: var(--text-muted);
   opacity: 0;
-  transition: opacity 0.15s, background 0.15s;
+  transition: opacity 0.15s, background 0.15s, color 0.15s;
   border-radius: 4px;
 }
 
@@ -455,6 +456,7 @@ footer {
 
 .tab-snooze-btn:hover {
   background: var(--border);
+  color: var(--text);
 }
 
 .snooze-menu {
@@ -538,6 +540,11 @@ footer {
   color: #fff;
 }
 
+[data-theme="dark"] .badge-timer {
+  background: rgba(251, 191, 36, 0.18);
+  color: #FCD34D;
+}
+
 .tab-unload-btn {
   background: none;
   border: none;
@@ -545,8 +552,9 @@ footer {
   padding: 2px 4px;
   border-radius: 4px;
   font-size: 12px;
+  color: var(--text-muted);
   opacity: 0;
-  transition: opacity 0.15s, background 0.15s;
+  transition: opacity 0.15s, background 0.15s, color 0.15s;
 }
 
 .tab-item:hover .tab-unload-btn {
@@ -555,6 +563,7 @@ footer {
 
 .tab-unload-btn:hover {
   background: var(--border);
+  color: var(--text);
 }
 
 .tab-item-empty {


### PR DESCRIPTION
## Summary
- Tab snooze/unload icon buttons had no explicit `color`, falling back to user-agent button grey - illegible on dark backgrounds. Now bound to `--text-muted` by default and `--text` on hover.
- `.badge-timer` used solid `--warning` (#FBBF24 bright yellow) with white text in dark mode - too glaring. Added a dark override using translucent amber bg + amber-300 fg, matching the existing `.badge-sleeping` / `.badge-active` dark-mode pattern.

## Test plan
- [x] Open popup in dark mode - verify the moon (unload) and pause (snooze) icons are clearly visible on tab-row hover
- [x] Hover a tab row - icons brighten from `--text-muted` to `--text`
- [x] Verify the timer badge "30m" now reads as soft amber on translucent amber, not bright yellow
- [x] Light mode unchanged: timer badge still solid orange with white text, icons still readable