### PR TITLE
fix(options): show correct Tabs Unloaded count and route reset through stats-collector

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -40,7 +40,7 @@ import {
   snoozeDomain,
   snoozeTab,
 } from "./snooze-manager.js";
-import { getStats, initStats } from "./stats-collector.js";
+import { getStats, initStats, resetStats } from "./stats-collector.js";
 import {
   checkAndUnloadInactiveTabs,
   cleanupStaleActivity,
@@ -563,6 +563,8 @@ async function handleMessage(message) {
     // Stats commands
     case "get-stats":
       return await getStats();
+    case "reset-stats":
+      return await resetStats();
     // Snooze commands
     case "snooze-tab":
       await snoozeTab(tabId, minutes);

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -190,9 +190,9 @@ function renderBlacklist() {
 // Load statistics
 async function loadStats() {
   const result = await chrome.storage.local.get("stats");
-  const stats = result.stats || { tabsUnloaded: 0, memorySaved: 0 };
+  const stats = result.stats || {};
 
-  elements.totalUnloaded.textContent = stats.tabsUnloaded || 0;
+  elements.totalUnloaded.textContent = stats.totalTabsSuspended || 0;
   elements.totalSaved.textContent = formatBytes(stats.memorySaved || 0);
 }
 
@@ -349,7 +349,7 @@ function setupEventListeners() {
 
   // Reset stats
   elements.resetStats.addEventListener("click", async () => {
-    await chrome.storage.local.set({ stats: { tabsUnloaded: 0, memorySaved: 0 } });
+    await chrome.runtime.sendMessage({ command: "reset-stats" });
     await loadStats();
     showStatus(t("statsReset"));
   });

--- a/tests/background/service-worker-contracts.test.js
+++ b/tests/background/service-worker-contracts.test.js
@@ -223,6 +223,7 @@ const ROUTED_COMMANDS = [
   "restore-session",
   "import-sessions",
   "get-stats",
+  "reset-stats",
   "snooze-tab",
   "snooze-domain",
   "cancel-tab-snooze",
@@ -265,6 +266,8 @@ function buildRouter(handlers) {
         return await handlers.importSessions(sessions);
       case "get-stats":
         return await handlers.getStats();
+      case "reset-stats":
+        return await handlers.resetStats();
       case "snooze-tab":
         await handlers.snoozeTab(tabId, minutes);
         return { success: true };
@@ -307,7 +310,8 @@ describe("service-worker-contracts: handleMessage routing", () => {
       deleteSession: vi.fn().mockResolvedValue(),
       restoreSession: vi.fn().mockResolvedValue({ success: true }),
       importSessions: vi.fn().mockResolvedValue({ added: 1, skipped: 0 }),
-      getStats: vi.fn().mockResolvedValue({ tabsUnloaded: 0 }),
+      getStats: vi.fn().mockResolvedValue({ totalTabsSuspended: 0 }),
+      resetStats: vi.fn().mockResolvedValue({ totalTabsSuspended: 0 }),
       snoozeTab: vi.fn().mockResolvedValue(),
       snoozeDomain: vi.fn().mockResolvedValue(),
       cancelTabSnooze: vi.fn().mockResolvedValue(),


### PR DESCRIPTION
## Summary

- `options.js` Statistics card always showed `Tabs Unloaded: 0` because `loadStats` read `stats.tabsUnloaded`, but `stats-collector.js` writes the all-time count to `stats.totalTabsSuspended`. Now reads the correct field (matches popup's ALL TIME).
- Reset Statistics wrote a legacy schema `{ tabsUnloaded: 0, memorySaved: 0 }` directly to storage. That destroyed `totalTabsSuspended`, `totalTabsSuspendedToday`, `todayDate`, and `installDate`, so subsequent `recordUnload` calls produced `NaN` (serialized as `null`) and popup's "Member Since" disappeared. Reset now sends a new `reset-stats` command handled by `stats-collector.resetStats()`, which writes the proper default schema.
- Added `reset-stats` to the service-worker router and contract test.

## Test plan

- [x] `pnpm vitest run tests/background/service-worker-contracts.test.js tests/background/stats-collector.test.js tests/options/options-contracts.test.js` - 81/81 passing
- [x] Manual: open `options.html`, confirm `Tabs Unloaded` matches popup `ALL TIME`
- [x] Manual: click `Reset Statistics`, confirm popup `TODAY`, `ALL TIME`, `RAM SAVED`, `Member Since` all reset cleanly (no `NaN`, Member Since shows today)