### PR TITLE
chore(cws): point all docs and links to the live store listing

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -72,7 +72,7 @@
 
 ### Aus dem Chrome Web Store
 
-Demnächst verfügbar.
+[TabRest aus dem Chrome Web Store installieren](https://chromewebstore.google.com/detail/tabrest-rest-your-tabs-fr/agajndkecodedlklmpnjgikglkpeopib).
 
 ## Funktionsweise
 

--- a/README.es.md
+++ b/README.es.md
@@ -72,7 +72,7 @@
 
 ### Desde Chrome Web Store
 
-Próximamente.
+[Instala TabRest desde Chrome Web Store](https://chromewebstore.google.com/detail/tabrest-rest-your-tabs-fr/agajndkecodedlklmpnjgikglkpeopib).
 
 ## Cómo funciona
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -72,7 +72,7 @@
 
 ### Depuis le Chrome Web Store
 
-Prochainement disponible.
+[Installer TabRest depuis le Chrome Web Store](https://chromewebstore.google.com/detail/tabrest-rest-your-tabs-fr/agajndkecodedlklmpnjgikglkpeopib).
 
 ## Fonctionnement
 

--- a/README.id.md
+++ b/README.id.md
@@ -72,7 +72,7 @@
 
 ### Dari Chrome Web Store
 
-Segera hadir.
+[Instal TabRest dari Chrome Web Store](https://chromewebstore.google.com/detail/tabrest-rest-your-tabs-fr/agajndkecodedlklmpnjgikglkpeopib).
 
 ## Cara Kerja
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -72,7 +72,7 @@
 
 ### Chrome Web Store からインストール
 
-近日公開予定。
+[Chrome Web Store から TabRest をインストール](https://chromewebstore.google.com/detail/tabrest-rest-your-tabs-fr/agajndkecodedlklmpnjgikglkpeopib)。
 
 ## 仕組み
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -72,7 +72,7 @@
 
 ### Chrome Web Store에서 설치
 
-출시 예정입니다.
+[Chrome Web Store에서 TabRest 설치](https://chromewebstore.google.com/detail/tabrest-rest-your-tabs-fr/agajndkecodedlklmpnjgikglkpeopib).
 
 ## 작동 방식
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@
 
 ### From Chrome Web Store
 
-Coming soon.
+[Install TabRest from the Chrome Web Store](https://chromewebstore.google.com/detail/tabrest-rest-your-tabs-fr/agajndkecodedlklmpnjgikglkpeopib).
 
 ## How It Works
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -72,7 +72,7 @@
 
 ### Pela Chrome Web Store
 
-Em breve.
+[Instale o TabRest na Chrome Web Store](https://chromewebstore.google.com/detail/tabrest-rest-your-tabs-fr/agajndkecodedlklmpnjgikglkpeopib).
 
 ## Como Funciona
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -72,7 +72,7 @@
 
 ### Из Chrome Web Store
 
-Скоро.
+[Установите TabRest из Chrome Web Store](https://chromewebstore.google.com/detail/tabrest-rest-your-tabs-fr/agajndkecodedlklmpnjgikglkpeopib).
 
 ## Принцип работы
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -72,7 +72,7 @@
 
 ### Từ Chrome Web Store
 
-Sắp ra mắt.
+[Cài đặt TabRest từ Chrome Web Store](https://chromewebstore.google.com/detail/tabrest-rest-your-tabs-fr/agajndkecodedlklmpnjgikglkpeopib).
 
 ## Cách hoạt động
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -72,7 +72,7 @@
 
 ### 从 Chrome Web Store 安装
 
-即将上线。
+[从 Chrome Web Store 安装 TabRest](https://chromewebstore.google.com/detail/tabrest-rest-your-tabs-fr/agajndkecodedlklmpnjgikglkpeopib)。
 
 ## 工作原理
 

--- a/docs/chrome-web-store-listing.md
+++ b/docs/chrome-web-store-listing.md
@@ -2,6 +2,9 @@
 
 All content for TabRest's Chrome Web Store listing. Translated versions live at `docs/<locale>/chrome-web-store-listing.md` for: vi, es, pt-BR, ja, zh-CN, ko, de, fr, ru, id (user-facing sections only).
 
+**Live listing:** <https://chromewebstore.google.com/detail/tabrest-rest-your-tabs-fr/agajndkecodedlklmpnjgikglkpeopib>
+**Extension ID:** `agajndkecodedlklmpnjgikglkpeopib`
+
 ## Basic Info
 
 Listing fields entered into the Chrome Web Store developer dashboard.

--- a/docs/project-overview-pdr.md
+++ b/docs/project-overview-pdr.md
@@ -138,4 +138,4 @@ optional_host_permissions: http://*/*, https://*/*
 
 - **Website:** https://tabrest.ohnice.app
 - **Repository:** GitHub (lamngockhuong/tabrest)
-- **Chrome Web Store:** Coming soon
+- **Chrome Web Store:** https://chromewebstore.google.com/detail/tabrest-rest-your-tabs-fr/agajndkecodedlklmpnjgikglkpeopib

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -100,7 +100,7 @@
 
 | Task                           | Priority | Status      |
 | ------------------------------ | -------- | ----------- |
-| Chrome Web Store listing       | High     | Pending     |
+| Chrome Web Store listing       | High     | Done        |
 | Store screenshots/promo images | High     | Done        |
 | Privacy policy page            | High     | Done        |
 | User testing & bug fixes       | High     | In Progress |

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -1197,12 +1197,11 @@ footer {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 8px 12px;
+  padding: 8px 8px 8px 12px;
   background: var(--primary);
   color: #fff;
   border-radius: 8px;
   margin-bottom: 12px;
-  position: relative;
   animation: slideDown 0.3s ease-out;
 }
 
@@ -1254,18 +1253,13 @@ footer {
 }
 
 .review-dismiss {
-  position: absolute;
-  top: 4px;
-  right: 4px;
-  background: none;
-  border: none;
-  color: rgba(255,255,255,0.6);
-  cursor: pointer;
-  padding: 2px;
+  color: rgba(255,255,255,0.7);
+  flex-shrink: 0;
 }
 
 .review-dismiss:hover {
   color: #fff;
+  background: rgba(255,255,255,0.15);
 }
 
 /* Modern Slim Scrollbar (WebKit) */

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -42,10 +42,10 @@
           <span data-icon="check"></span> <span data-i18n="yes">Yes!</span>
         </button>
         <button class="review-btn review-no" id="review-no" title="Report issue">
-          <span data-icon="x"></span> <span data-i18n="notReally">Not really</span>
+          <span data-icon="messageCircle"></span> <span data-i18n="notReally">Not really</span>
         </button>
       </div>
-      <button class="review-dismiss" id="review-dismiss" title="Dismiss">
+      <button class="icon-btn review-dismiss" id="review-dismiss" title="Dismiss">
         <span data-icon="x"></span>
       </button>
     </div>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -546,7 +546,8 @@ async function renderDetailedStats() {
 }
 
 // Review prompt URLs
-const REVIEW_URL = "https://chromewebstore.google.com/detail/tabrest-rest-your-tabs-fr/agajndkecodedlklmpnjgikglkpeopib/reviews";
+const REVIEW_URL =
+  "https://chromewebstore.google.com/detail/tabrest-rest-your-tabs-fr/agajndkecodedlklmpnjgikglkpeopib/reviews";
 const ISSUES_URL = "https://github.com/lamngockhuong/tabrest/issues";
 const NEW_BUG_ISSUE_URL =
   "https://github.com/lamngockhuong/tabrest/issues/new?template=bug_report.md";

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -546,7 +546,7 @@ async function renderDetailedStats() {
 }
 
 // Review prompt URLs
-const REVIEW_URL = "https://chromewebstore.google.com/detail/tabrest/placeholder-id/reviews";
+const REVIEW_URL = "https://chromewebstore.google.com/detail/tabrest-rest-your-tabs-fr/agajndkecodedlklmpnjgikglkpeopib/reviews";
 const ISSUES_URL = "https://github.com/lamngockhuong/tabrest/issues";
 const NEW_BUG_ISSUE_URL =
   "https://github.com/lamngockhuong/tabrest/issues/new?template=bug_report.md";

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -22,7 +22,7 @@ const homeLink = getLocalizedPath('/', locale);
         {t.footer.cta.subtitle}
       </p>
       <a
-        href="https://chrome.google.com/webstore"
+        href="https://chromewebstore.google.com/detail/tabrest-rest-your-tabs-fr/agajndkecodedlklmpnjgikglkpeopib"
         target="_blank"
         rel="noopener noreferrer"
         class="inline-block px-8 py-3 bg-primary hover:bg-primary-hover text-white rounded-lg font-semibold transition-colors"
@@ -81,7 +81,7 @@ const homeLink = getLocalizedPath('/', locale);
           </li>
           <li>
             <a
-              href="https://chrome.google.com/webstore"
+              href="https://chromewebstore.google.com/detail/tabrest-rest-your-tabs-fr/agajndkecodedlklmpnjgikglkpeopib"
               target="_blank"
               rel="noopener noreferrer"
               class="text-text-muted dark:text-text-muted-dark hover:text-primary dark:hover:text-primary-light transition-colors"

--- a/website/src/components/LandingPage.astro
+++ b/website/src/components/LandingPage.astro
@@ -22,7 +22,7 @@ const t = useTranslations(locale);
       {t.hero.description}
     </p>
     <a
-      href="https://chrome.google.com/webstore"
+      href="https://chromewebstore.google.com/detail/tabrest-rest-your-tabs-fr/agajndkecodedlklmpnjgikglkpeopib"
       target="_blank"
       rel="noopener noreferrer"
       class="inline-block px-8 py-4 bg-primary hover:bg-primary-hover text-white text-lg rounded-lg font-semibold transition-colors shadow-lg"
@@ -207,7 +207,7 @@ const t = useTranslations(locale);
 
     <div class="mt-12 text-center">
       <a
-        href="https://chrome.google.com/webstore"
+        href="https://chromewebstore.google.com/detail/tabrest-rest-your-tabs-fr/agajndkecodedlklmpnjgikglkpeopib"
         target="_blank"
         rel="noopener noreferrer"
         class="inline-block px-8 py-3 bg-primary hover:bg-primary-hover text-white rounded-lg font-semibold transition-colors"

--- a/website/src/content/docs/en/getting-started.mdx
+++ b/website/src/content/docs/en/getting-started.mdx
@@ -14,7 +14,7 @@ TabRest is a browser extension that automatically unloads inactive tabs to free 
 ### From Browser Web Store
 
 **Chrome users:**
-1. Visit the [TabRest listing on Chrome Web Store](https://chrome.google.com/webstore) (coming soon)
+1. Visit the [TabRest listing on Chrome Web Store](https://chromewebstore.google.com/detail/tabrest-rest-your-tabs-fr/agajndkecodedlklmpnjgikglkpeopib)
 2. Click **Add to Chrome**
 
 **Edge users:**

--- a/website/src/content/docs/vi/getting-started.mdx
+++ b/website/src/content/docs/vi/getting-started.mdx
@@ -14,7 +14,7 @@ TabRest là tiện ích trình duyệt tự động giải phóng các tab khôn
 ### Từ Web Store
 
 **Người dùng Chrome:**
-1. Truy cập [TabRest trên Chrome Web Store](https://chrome.google.com/webstore) (sắp ra mắt)
+1. Truy cập [TabRest trên Chrome Web Store](https://chromewebstore.google.com/detail/tabrest-rest-your-tabs-fr/agajndkecodedlklmpnjgikglkpeopib)
 2. Nhấn **Thêm vào Chrome**
 
 **Người dùng Edge:**


### PR DESCRIPTION
## Summary

- TabRest is now published on the Chrome Web Store: https://chromewebstore.google.com/detail/tabrest-rest-your-tabs-fr/agajndkecodedlklmpnjgikglkpeopib
- Replaces every "coming soon" / placeholder store URL across 11 README locales, project docs, the popup review prompt, and the website (landing, footer, getting-started for en/vi)
- Fixes the popup review prompt layout: the absolute-positioned dismiss button overlapped "Not really" — now flows naturally and reuses the shared \`.icon-btn\` baseline (same pattern as \`form-perm-dismiss\`)
- Removes the duplicate X icon: "Not really" now uses \`messageCircle\` so it reads as "leave feedback" instead of mirroring the dismiss X

## Notes

- Microsoft Edge Add-ons "(coming soon)" lines in \`getting-started.mdx\` left intentionally — that listing is not published yet
- \`AGENTS.md\` / \`CLAUDE.md\` left out of this PR (auto-generated GitNexus index updates, unrelated)

## Test plan

- [x] Reload extension, confirm popup review prompt renders cleanly with no overlap (force-show with \`chrome.storage.local.set({ tabrest_stats: { totalTabsSuspended: 10 }, reviewPromptCompleted: false, reviewPromptDismissCount: 0 })\`)
- [x] Click "Yes!" — opens the live store review URL
- [x] Click "Not really" — opens GitHub issues (icon is now chat bubble)
- [x] Click dismiss X — banner hides, dismiss count increments
- [x] Spot-check website landing page and footer CTAs go to the live listing