### PR TITLE
feat(whitelist): surface Chrome Memory Saver coexistence note

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -182,6 +182,12 @@
   "whitelistHelp": {
     "message": "Sites, die nie automatisch entladen werden"
   },
+  "memorySaverNoteBody": {
+    "message": "Chromes integrierter Speichersparmodus läuft separat und kann diese Sites trotzdem entladen."
+  },
+  "learnMoreLink": {
+    "message": "Mehr erfahren"
+  },
   "addPlaceholder": {
     "message": "example.com"
   },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -241,6 +241,14 @@
     "message": "Sites that will never be unloaded automatically",
     "description": "Options help text"
   },
+  "memorySaverNoteBody": {
+    "message": "Chrome's built-in Memory Saver runs separately and may still unload these sites.",
+    "description": "Info note body shown next to whitelist surfaces (onboarding step and options page) explaining that Chrome's Memory Saver is independent of TabRest."
+  },
+  "learnMoreLink": {
+    "message": "Learn more",
+    "description": "Generic link label that opens the relevant docs page in a new tab."
+  },
   "addPlaceholder": {
     "message": "example.com",
     "description": "Input placeholder"

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -182,6 +182,12 @@
   "whitelistHelp": {
     "message": "Sitios que nunca se descargarán automáticamente"
   },
+  "memorySaverNoteBody": {
+    "message": "El Ahorro de memoria integrado de Chrome funciona por separado y aún puede descargar estos sitios."
+  },
+  "learnMoreLink": {
+    "message": "Más información"
+  },
   "addPlaceholder": {
     "message": "example.com"
   },

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -182,6 +182,12 @@
   "whitelistHelp": {
     "message": "Sites qui ne seront jamais déchargés automatiquement"
   },
+  "memorySaverNoteBody": {
+    "message": "L'économiseur de mémoire intégré de Chrome fonctionne séparément et peut tout de même décharger ces sites."
+  },
+  "learnMoreLink": {
+    "message": "En savoir plus"
+  },
   "addPlaceholder": {
     "message": "example.com"
   },

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -182,6 +182,12 @@
   "whitelistHelp": {
     "message": "Situs yang tidak akan pernah dibongkar secara otomatis"
   },
+  "memorySaverNoteBody": {
+    "message": "Penghemat Memori bawaan Chrome berjalan terpisah dan masih dapat membongkar situs ini."
+  },
+  "learnMoreLink": {
+    "message": "Pelajari lebih lanjut"
+  },
   "addPlaceholder": {
     "message": "example.com"
   },

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -182,6 +182,12 @@
   "whitelistHelp": {
     "message": "自動アンロードの対象にならないサイト"
   },
+  "memorySaverNoteBody": {
+    "message": "Chrome の組み込みメモリ セーバーは独立して動作し、これらのサイトをアンロードすることがあります。"
+  },
+  "learnMoreLink": {
+    "message": "詳細"
+  },
   "addPlaceholder": {
     "message": "example.com"
   },

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -182,6 +182,12 @@
   "whitelistHelp": {
     "message": "자동으로 언로드되지 않는 사이트"
   },
+  "memorySaverNoteBody": {
+    "message": "Chrome 내장 메모리 절약 모드는 별도로 실행되며 이러한 사이트를 언로드할 수 있습니다."
+  },
+  "learnMoreLink": {
+    "message": "자세히 보기"
+  },
   "addPlaceholder": {
     "message": "example.com"
   },

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -182,6 +182,12 @@
   "whitelistHelp": {
     "message": "Sites que nunca serão descarregados automaticamente"
   },
+  "memorySaverNoteBody": {
+    "message": "O Economizador de memória integrado do Chrome é executado separadamente e ainda pode descarregar esses sites."
+  },
+  "learnMoreLink": {
+    "message": "Saiba mais"
+  },
   "addPlaceholder": {
     "message": "exemplo.com"
   },

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -182,6 +182,12 @@
   "whitelistHelp": {
     "message": "Сайты, которые никогда не выгружаются автоматически"
   },
+  "memorySaverNoteBody": {
+    "message": "Встроенная экономия памяти Chrome работает отдельно и может выгружать эти сайты."
+  },
+  "learnMoreLink": {
+    "message": "Подробнее"
+  },
   "addPlaceholder": {
     "message": "example.com"
   },

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -178,6 +178,12 @@
   "whitelistHelp": {
     "message": "Các trang sẽ không bao giờ bị dỡ tự động"
   },
+  "memorySaverNoteBody": {
+    "message": "Tính năng Memory Saver tích hợp của Chrome chạy độc lập và vẫn có thể dỡ các trang này."
+  },
+  "learnMoreLink": {
+    "message": "Tìm hiểu thêm"
+  },
   "addPlaceholder": {
     "message": "example.com"
   },

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -182,6 +182,12 @@
   "whitelistHelp": {
     "message": "这些网站不会被自动释放"
   },
+  "memorySaverNoteBody": {
+    "message": "Chrome 内置的内存节省程序独立运行，仍可能释放这些网站。"
+  },
+  "learnMoreLink": {
+    "message": "了解更多"
+  },
   "addPlaceholder": {
     "message": "example.com"
   },

--- a/docs/unload-decision-matrix.md
+++ b/docs/unload-decision-matrix.md
@@ -105,3 +105,23 @@ Trigger arrives (Timer/Memory/Heap/Blacklist)
 | Battery Saver | 0.5x (more aggressive) | -10% (lower threshold)  |
 | Normal        | 1.0x                   | 0%                      |
 | Performance   | 2.0x (less aggressive) | +10% (higher threshold) |
+
+## Coexistence with Chrome Memory Saver
+
+Chrome ships its own tab discarding system (Memory Saver, `chrome://settings/performance`, since Chrome 108). This runs at the browser level and does **not** consult any extension, TabRest included.
+
+### What this means in practice
+
+- Whitelist and snooze are TabRest flags stored in `chrome.storage`. They prevent **TabRest** from discarding a tab. They do **not** prevent **Chrome Memory Saver** from discarding the same tab.
+- Chrome Memory Saver respects its own conditions only: tabs playing audio, using camera/mic, with unsaved form input, pinned, or under "Always keep these sites active" in Chrome's own list.
+- No Chrome Extension API allows opting a tab out of Memory Saver.
+
+### Recommended user setups
+
+| Setup                                                                                                          | Tradeoff                                                            |
+| -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Disable Chrome Memory Saver, use TabRest only                                                                  | Cleanest behavior; full control via TabRest settings                |
+| Keep Chrome Memory Saver on AND duplicate critical domains into Chrome's "Always keep these sites active" list | Two systems running; user must maintain two lists                   |
+| Keep Chrome Memory Saver on without duplicating                                                                | Whitelist/snooze appear "broken" for tabs Chrome decides to discard |
+
+This is a Chrome platform constraint, not a TabRest limitation. See `plans/260430-1208-memory-saver-coexistence/plan.md` for a planned conflict-detection feature that surfaces this situation in the UI.

--- a/docs/unload-decision-matrix.md
+++ b/docs/unload-decision-matrix.md
@@ -124,4 +124,4 @@ Chrome ships its own tab discarding system (Memory Saver, `chrome://settings/per
 | Keep Chrome Memory Saver on AND duplicate critical domains into Chrome's "Always keep these sites active" list | Two systems running; user must maintain two lists                   |
 | Keep Chrome Memory Saver on without duplicating                                                                | Whitelist/snooze appear "broken" for tabs Chrome decides to discard |
 
-This is a Chrome platform constraint, not a TabRest limitation. See `plans/260430-1208-memory-saver-coexistence/plan.md` for a planned conflict-detection feature that surfaces this situation in the UI.
+This is a Chrome platform constraint, not a TabRest limitation.

--- a/docs/vi/unload-decision-matrix.md
+++ b/docs/vi/unload-decision-matrix.md
@@ -105,3 +105,23 @@ Trigger đến (Timer/Memory/Heap/Blacklist)
 | Battery Saver | 0.5x (tích cực hơn)    | -10% (ngưỡng thấp hơn) |
 | Normal        | 1.0x                   | 0%                     |
 | Performance   | 2.0x (ít tích cực hơn) | +10% (ngưỡng cao hơn)  |
+
+## Cùng Tồn Tại Với Chrome Memory Saver
+
+Chrome có sẵn cơ chế discard tab riêng (Memory Saver, `chrome://settings/performance`, từ Chrome 108). Cơ chế này chạy ở tầng trình duyệt và **không** tham khảo bất kỳ extension nào, kể cả TabRest.
+
+### Điều này nghĩa là gì trong thực tế
+
+- Whitelist và snooze là cờ của TabRest lưu trong `chrome.storage`. Chúng ngăn **TabRest** discard một tab. Chúng **không** ngăn được **Chrome Memory Saver** discard cùng tab đó.
+- Chrome Memory Saver chỉ tôn trọng các điều kiện riêng của nó: tab đang phát audio, đang dùng camera/mic, có form chưa lưu, đã pin, hoặc nằm trong danh sách "Always keep these sites active" của Chrome.
+- Không có Chrome Extension API nào cho phép loại trừ một tab khỏi Memory Saver.
+
+### Các thiết lập khuyến nghị cho user
+
+| Thiết lập                                                                                                                | Đánh đổi                                                             |
+| ------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
+| Tắt Chrome Memory Saver, chỉ dùng TabRest                                                                                | Hành vi sạch nhất; toàn quyền kiểm soát qua cài đặt TabRest          |
+| Giữ Chrome Memory Saver bật VÀ duplicate các domain quan trọng vào danh sách "Always keep these sites active" của Chrome | Hai hệ thống cùng chạy; user phải duy trì hai danh sách              |
+| Giữ Chrome Memory Saver bật mà không duplicate                                                                           | Whitelist/snooze trông như "hỏng" với những tab Chrome quyết discard |
+
+Đây là giới hạn của nền tảng Chrome, không phải giới hạn của TabRest. Xem `plans/260430-1208-memory-saver-coexistence/plan.md` cho feature phát hiện conflict đã được lên kế hoạch để hiển thị tình huống này trong UI.

--- a/docs/vi/unload-decision-matrix.md
+++ b/docs/vi/unload-decision-matrix.md
@@ -124,4 +124,4 @@ Chrome có sẵn cơ chế discard tab riêng (Memory Saver, `chrome://settings/
 | Giữ Chrome Memory Saver bật VÀ duplicate các domain quan trọng vào danh sách "Always keep these sites active" của Chrome | Hai hệ thống cùng chạy; user phải duy trì hai danh sách              |
 | Giữ Chrome Memory Saver bật mà không duplicate                                                                           | Whitelist/snooze trông như "hỏng" với những tab Chrome quyết discard |
 
-Đây là giới hạn của nền tảng Chrome, không phải giới hạn của TabRest. Xem `plans/260430-1208-memory-saver-coexistence/plan.md` cho feature phát hiện conflict đã được lên kế hoạch để hiển thị tình huống này trong UI.
+Đây là giới hạn của nền tảng Chrome, không phải giới hạn của TabRest.

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -282,6 +282,10 @@
           <h2 data-i18n="whitelist">Whitelist</h2>
         </header>
         <p class="help" data-i18n="whitelistHelp">Sites that will never be unloaded automatically</p>
+        <p class="help">
+          <span data-i18n="memorySaverNoteBody"></span>
+          <a id="memory-saver-docs-link" target="_blank" rel="noopener noreferrer" data-i18n="learnMoreLink"></a>
+        </p>
         <div id="whitelist-container"></div>
         <div class="add-domain">
           <input type="text" id="new-whitelist" data-i18n-placeholder="addPlaceholder" placeholder="example.com">

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,6 +1,6 @@
 import { SETTINGS_DEFAULTS } from "../shared/constants.js";
 import { isValidDsn } from "../shared/error-reporter.js";
-import { localizeHtml, t } from "../shared/i18n.js";
+import { getMemorySaverDocsUrl, localizeHtml, t } from "../shared/i18n.js";
 import { injectIcons } from "../shared/icons.js";
 import { exportPayload, parseImport } from "../shared/import-export.js";
 import {
@@ -76,6 +76,11 @@ async function init() {
   onThemeChange((theme) => updateThemeIcon(elements.themeIcon, elements.themeToggle, theme));
   localizeHtml();
   injectIcons();
+
+  const memorySaverDocsLink = document.getElementById("memory-saver-docs-link");
+  if (memorySaverDocsLink) {
+    memorySaverDocsLink.href = getMemorySaverDocsUrl();
+  }
 
   await loadSettings();
   await loadStats();

--- a/src/pages/onboarding/onboarding.css
+++ b/src/pages/onboarding/onboarding.css
@@ -527,6 +527,33 @@
   color: var(--text-muted);
 }
 
+.ob-info-note {
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.5;
+  padding: 10px 12px;
+  background: var(--card-elevated);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  margin: 0;
+}
+
+.ob-info-note a {
+  color: var(--primary);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.ob-info-note a:hover {
+  text-decoration: underline;
+}
+
+.ob-info-note a:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
 @media (max-width: 480px) {
   .ob-radio-grid,
   .ob-checkbox-grid {

--- a/src/pages/onboarding/step-renderers.js
+++ b/src/pages/onboarding/step-renderers.js
@@ -3,7 +3,7 @@ import {
   POWER_MODE_NAME_KEY,
   WHITELIST_SUGGESTIONS,
 } from "../../shared/constants.js";
-import { t } from "../../shared/i18n.js";
+import { getMemorySaverDocsUrl, t } from "../../shared/i18n.js";
 import { clearChildren, createEl } from "./dom-helpers.js";
 
 const POWER_MODES = Object.keys(POWER_MODE_NAME_KEY);
@@ -67,6 +67,22 @@ export function renderWhitelist(bodyEl, settings) {
     );
   }
   bodyEl.appendChild(grid);
+  bodyEl.appendChild(
+    createEl(
+      "p",
+      { class: "ob-info-note" },
+      `${t("memorySaverNoteBody")} `,
+      createEl(
+        "a",
+        {
+          href: getMemorySaverDocsUrl(),
+          target: "_blank",
+          rel: "noopener noreferrer",
+        },
+        t("learnMoreLink"),
+      ),
+    ),
+  );
   return () =>
     Array.from(bodyEl.querySelectorAll("input[type=checkbox]:checked")).map((b) => b.value);
 }

--- a/src/shared/i18n.js
+++ b/src/shared/i18n.js
@@ -46,3 +46,15 @@ export function localizeHtml() {
 export function getUILanguage() {
   return chrome.i18n.getUILanguage();
 }
+
+const DOCS_BASE = "https://tabrest.ohnice.app";
+
+// Anchors are slugified headings in website/src/content/docs/{en,vi}/whitelist-config.mdx.
+// Vietnamese diacritics are stripped by Astro's slugger.
+export function getMemorySaverDocsUrl() {
+  const lang = getUILanguage().toLowerCase();
+  if (lang.startsWith("vi")) {
+    return `${DOCS_BASE}/vi/docs/whitelist-config#cung-ton-tai-voi-chrome-memory-saver`;
+  }
+  return `${DOCS_BASE}/docs/whitelist-config#coexistence-with-chrome-memory-saver`;
+}

--- a/website/src/content/docs/en/faq.mdx
+++ b/website/src/content/docs/en/faq.mdx
@@ -281,6 +281,32 @@ TabRest should work alongside other tab management extensions, but:
 
 **Recommendation**: Use one tab management extension at a time.
 
+### How does TabRest interact with Chrome's built-in Memory Saver?
+
+Chrome 108+ ships **Memory Saver** at `chrome://settings/performance`, which discards inactive tabs at the browser level. TabRest and Memory Saver run independently:
+
+- **Memory Saver does not consult TabRest**. There is no Chrome extension API to opt a tab out of Memory Saver.
+- **TabRest's whitelist and snooze only apply to TabRest's own unload pipeline**. They do not prevent Chrome from discarding the same tab.
+
+**If both are enabled**, a whitelisted tab can still be discarded by Chrome. To prevent this, either:
+
+1. Turn off Chrome Memory Saver and let TabRest manage everything (recommended for users who want fine-grained control), or
+2. Keep both on and also add critical domains to Chrome's **Always keep these sites active** list at `chrome://settings/performance`
+
+See [Whitelist Configuration](/docs/whitelist-config#coexistence-with-chrome-memory-saver) for details.
+
+### Why is my whitelisted tab still being unloaded?
+
+The most common cause is Chrome Memory Saver running in parallel with TabRest. TabRest's whitelist does not affect Chrome's Memory Saver. See the question above for the fix.
+
+Other possible causes:
+
+- The domain format is wrong (use `example.com`, not `https://example.com/path`)
+- Blacklist mode is enabled (whitelist becomes the unload list)
+- Another tab management extension is also installed
+
+See [Troubleshooting -> Whitelist Not Working](/docs/troubleshooting#whitelist-not-working) for full diagnosis steps.
+
 ## Troubleshooting
 
 ### Why do some tabs reload immediately after unloading?

--- a/website/src/content/docs/en/troubleshooting.mdx
+++ b/website/src/content/docs/en/troubleshooting.mdx
@@ -233,6 +233,25 @@ Domain matching is case-insensitive:
 
 **Solution**: Use lowercase for consistency.
 
+### Chrome Memory Saver Is Also Active
+
+**Most common cause when whitelist appears broken on Chrome 108+.**
+
+Chrome ships its own tab discarding feature (`chrome://settings/performance` -> Memory Saver). It runs at the browser level and ignores extension state. If Memory Saver is enabled, it can discard a tab even when the domain is on TabRest's whitelist - because Memory Saver never asks TabRest.
+
+**How to confirm this is the cause**:
+
+1. The tab unloads without TabRest's suspend warning toast appearing first
+2. The tab unloads even when TabRest is paused or disabled
+3. You see Memory Saver toggled on at `chrome://settings/performance`
+
+**Solution (pick one)**:
+
+- **Option A**: Open `chrome://settings/performance` and turn Memory Saver off. TabRest will then have full control.
+- **Option B**: Keep Memory Saver on, but also add the domain to Chrome's **Always keep these sites active** list at `chrome://settings/performance`. You will need to keep TabRest's whitelist and Chrome's list in sync manually.
+
+See [Whitelist Configuration -> Coexistence with Chrome Memory Saver](/docs/whitelist-config#coexistence-with-chrome-memory-saver) for the full explanation.
+
 ## Form Protection Not Working
 
 **Issue**: Tabs with unsaved forms get unloaded.

--- a/website/src/content/docs/en/whitelist-config.mdx
+++ b/website/src/content/docs/en/whitelist-config.mdx
@@ -240,6 +240,45 @@ TabRest currently does **not** support wildcards (e.g., `*.google.com`). Add eac
 ❌ Not supported: *.google.com
 ```
 
+## Coexistence with Chrome Memory Saver
+
+Since Chrome 108, Chrome ships its own tab discarding feature called **Memory Saver** (at `chrome://settings/performance`). It runs at the browser level and does **not** consult any extension, including TabRest.
+
+### What this means
+
+TabRest's whitelist tells **TabRest** not to unload a domain. It does **not** tell **Chrome** to keep the tab loaded. If Chrome Memory Saver is enabled and decides a tab has been inactive long enough, it will discard the tab even when the domain is on TabRest's whitelist.
+
+This is a Chrome platform constraint. No extension API exists to opt a tab out of Memory Saver.
+
+### Symptoms of this situation
+
+- Domain is in your TabRest whitelist
+- Tab still gets unloaded automatically
+- Discard happened without TabRest's suspend warning toast (because TabRest didn't do it)
+
+### How to fully protect a tab
+
+Pick **one** of:
+
+**Option A (recommended): turn off Chrome Memory Saver**
+
+1. Open `chrome://settings/performance`
+2. Toggle **Memory Saver** off
+3. TabRest now has full control; your whitelist behaves as expected
+
+**Option B: maintain a second list inside Chrome**
+
+1. Open `chrome://settings/performance`
+2. Under **Always keep these sites active**, add the same domains you have in TabRest's whitelist
+3. Both systems will skip those tabs
+
+**Naturally protected tabs** (work in both systems without configuration):
+
+- Tab playing audio or video
+- Tab using camera or microphone
+- Tab with unsaved form input
+- Pinned tab
+
 ## Privacy
 
 Whitelist entries are:

--- a/website/src/content/docs/vi/faq.mdx
+++ b/website/src/content/docs/vi/faq.mdx
@@ -269,6 +269,32 @@ TabRest nên hoạt động cùng các tiện ích quản lý tab khác, nhưng:
 
 **Khuyến nghị**: Dùng một tiện ích quản lý tab tại một thời điểm.
 
+### TabRest tương tác thế nào với Memory Saver có sẵn của Chrome?
+
+Từ Chrome 108, Chrome có sẵn **Memory Saver** tại `chrome://settings/performance`, tự động giải phóng tab không hoạt động ở cấp trình duyệt. TabRest và Memory Saver chạy độc lập:
+
+- **Memory Saver không tham khảo TabRest**. Không có Chrome Extension API nào cho phép loại trừ một tab khỏi Memory Saver.
+- **Danh sách trắng và snooze của TabRest chỉ áp dụng cho cơ chế giải phóng của TabRest**. Chúng không ngăn được Chrome tự giải phóng cùng tab đó.
+
+**Nếu bật cả hai**, một tab trong danh sách trắng vẫn có thể bị Chrome giải phóng. Để tránh điều này, hãy chọn một trong hai cách:
+
+1. Tắt Chrome Memory Saver và để TabRest quản lý hoàn toàn (khuyến nghị cho người dùng muốn kiểm soát chi tiết), hoặc
+2. Giữ cả hai bật, đồng thời thêm các domain quan trọng vào danh sách **Always keep these sites active** của Chrome tại `chrome://settings/performance`
+
+Xem [Cấu hình danh sách trắng](/vi/docs/whitelist-config#cùng-tồn-tại-với-chrome-memory-saver) để biết chi tiết.
+
+### Tại sao tab trong danh sách trắng vẫn bị giải phóng?
+
+Nguyên nhân phổ biến nhất là Chrome Memory Saver chạy song song với TabRest. Danh sách trắng của TabRest không ảnh hưởng tới Memory Saver của Chrome. Xem câu hỏi phía trên để biết cách khắc phục.
+
+Các nguyên nhân khác có thể có:
+
+- Định dạng domain sai (dùng `example.com`, không phải `https://example.com/path`)
+- Đang bật chế độ blacklist (danh sách trắng trở thành danh sách giải phóng)
+- Có tiện ích quản lý tab khác cũng được cài đặt
+
+Xem [Xử lý sự cố -> Danh sách trắng không hoạt động](/vi/docs/troubleshooting#danh-sách-trắng-không-hoạt-động) để biết các bước chẩn đoán đầy đủ.
+
 ## Xử lý sự cố
 
 ### Tại sao một số tab tải lại ngay sau khi giải phóng?

--- a/website/src/content/docs/vi/troubleshooting.mdx
+++ b/website/src/content/docs/vi/troubleshooting.mdx
@@ -233,6 +233,25 @@ Khớp domain không phân biệt chữ hoa/thường:
 
 **Giải pháp**: Dùng chữ thường để nhất quán.
 
+### Chrome Memory Saver đang bật song song
+
+**Đây là nguyên nhân phổ biến nhất khi danh sách trắng có vẻ không hoạt động trên Chrome 108+.**
+
+Chrome có sẵn tính năng giải phóng tab (`chrome://settings/performance` -> Memory Saver). Tính năng này chạy ở tầng trình duyệt và bỏ qua trạng thái của extension. Nếu Memory Saver đang bật, nó có thể giải phóng một tab dù domain nằm trong danh sách trắng của TabRest, vì Memory Saver không bao giờ hỏi TabRest.
+
+**Cách xác nhận đây là nguyên nhân**:
+
+1. Tab bị giải phóng mà không thấy toast cảnh báo của TabRest hiện trước
+2. Tab vẫn bị giải phóng ngay cả khi TabRest đang tạm dừng hoặc tắt
+3. Bạn thấy Memory Saver đang được bật tại `chrome://settings/performance`
+
+**Giải pháp (chọn một)**:
+
+- **Cách A**: Mở `chrome://settings/performance` và tắt Memory Saver. TabRest sẽ có toàn quyền kiểm soát.
+- **Cách B**: Giữ Memory Saver bật, đồng thời thêm domain vào danh sách **Always keep these sites active** của Chrome tại `chrome://settings/performance`. Bạn sẽ phải tự đồng bộ giữa danh sách trắng của TabRest và danh sách của Chrome.
+
+Xem [Cấu hình danh sách trắng -> Cùng tồn tại với Chrome Memory Saver](/vi/docs/whitelist-config#cùng-tồn-tại-với-chrome-memory-saver) để biết giải thích đầy đủ.
+
 ## Bảo vệ form không hoạt động
 
 **Vấn đề**: Tab có form chưa lưu bị giải phóng.

--- a/website/src/content/docs/vi/whitelist-config.mdx
+++ b/website/src/content/docs/vi/whitelist-config.mdx
@@ -249,6 +249,45 @@ TabRest hiện **không** hỗ trợ wildcard (vd: `*.google.com`). Thêm từng
 ❌ Không hỗ trợ: *.google.com
 ```
 
+## Cùng tồn tại với Chrome Memory Saver
+
+Từ Chrome 108, Chrome có sẵn tính năng giải phóng tab gọi là **Memory Saver** (tại `chrome://settings/performance`). Tính năng này chạy ở tầng trình duyệt và **không** tham khảo bất kỳ extension nào, bao gồm cả TabRest.
+
+### Điều này nghĩa là gì
+
+Danh sách trắng của TabRest yêu cầu **TabRest** không giải phóng một domain. Nó **không** yêu cầu **Chrome** giữ tab được tải. Nếu Chrome Memory Saver đang bật và quyết định một tab đã không hoạt động đủ lâu, Chrome sẽ giải phóng tab đó dù domain nằm trong danh sách trắng của TabRest.
+
+Đây là giới hạn của nền tảng Chrome. Không có Extension API nào cho phép loại trừ một tab khỏi Memory Saver.
+
+### Dấu hiệu nhận biết
+
+- Domain đã có trong danh sách trắng của TabRest
+- Tab vẫn bị giải phóng tự động
+- Tab bị giải phóng mà không thấy toast cảnh báo của TabRest (vì TabRest không phải bên giải phóng)
+
+### Cách bảo vệ tab hoàn toàn
+
+Chọn **một** trong các cách sau:
+
+**Cách A (khuyến nghị): tắt Chrome Memory Saver**
+
+1. Mở `chrome://settings/performance`
+2. Tắt **Memory Saver**
+3. TabRest sẽ có toàn quyền kiểm soát; danh sách trắng hoạt động đúng như mong đợi
+
+**Cách B: duy trì danh sách thứ hai trong Chrome**
+
+1. Mở `chrome://settings/performance`
+2. Trong mục **Always keep these sites active** (Luôn giữ các trang này hoạt động), thêm cùng các domain bạn đã có trong danh sách trắng của TabRest
+3. Cả hai hệ thống sẽ bỏ qua các tab đó
+
+**Tab được bảo vệ tự nhiên** (hoạt động ở cả hai hệ thống mà không cần cấu hình):
+
+- Tab đang phát audio hoặc video
+- Tab đang dùng camera hoặc microphone
+- Tab có form chưa lưu
+- Tab đã pin
+
 ## Quyền riêng tư
 
 Các mục danh sách trắng:


### PR DESCRIPTION
## Summary
- Surface Chrome Memory Saver coexistence information at onboarding whitelist step and options page
- Users now understand that Chrome's built-in Memory Saver can discard whitelisted tabs independently
- Both UI locations link to updated docs (FAQ, troubleshooting, whitelist-config, decision matrix) in en/vi

## Test plan
- [x] Load extension in Chrome (chrome://extensions → Load unpacked)
- [x] Go through onboarding: verify "Memory Saver" info note appears on whitelist step
- [x] Click "Learn more" link: opens correct docs page (language-aware)
- [x] Go to options page: verify Memory Saver note appears in whitelist section
- [x] Test in both English and Vietnamese UI modes
- [x] Verify all 11 locale translations are present (de, en, es, fr, id, ja, ko, pt_BR, ru, vi, zh_CN)

## Reference
Plan: `/plans/260430-1208-memory-saver-coexistence`

**Note:** AGENTS.md and CLAUDE.md (GitNexus index auto-updates) intentionally excluded from this PR.