### PR TITLE
docs(i18n/vi): translation quality review across 14 files

### DIFF
--- a/README.vi.md
+++ b/README.vi.md
@@ -8,7 +8,7 @@
 <h1 align="center">TabRest</h1>
 
 <p align="center">
-  Cho tab nghỉ ngơi, giải phóng bộ nhớ - tiện ích Chrome tự động unload các tab không hoạt động.
+  Cho tab nghỉ ngơi, giải phóng bộ nhớ - tiện ích Chrome tự động giải phóng các tab không hoạt động.
 </p>
 
 <p align="center">
@@ -21,44 +21,44 @@
 
 ## Tính năng
 
-- **Tự động unload tab không hoạt động** - Hẹn giờ tuỳ chỉnh (5 phút đến 4 giờ)
-- **Ngưỡng bộ nhớ** - Unload khi RAM vượt 60-95%
-- **Giới hạn bộ nhớ mỗi tab** - Unload tab dùng >100MB-1GB JS heap
-- **Unload khi khởi động** - Giải phóng bộ nhớ khi mở trình duyệt
-- **Điều khiển thủ công** - Unload tab hiện tại/trái/phải/khác
-- **Đóng tab trùng lặp** - Một cú nhấp dedup trong cửa sổ hiện tại
+- **Tự động giải phóng tab không hoạt động** - Hẹn giờ tuỳ chỉnh (5 phút đến 4 giờ)
+- **Ngưỡng bộ nhớ** - Giải phóng khi RAM vượt 60-95%
+- **Giới hạn bộ nhớ mỗi tab** - Giải phóng tab dùng >100MB-1GB JS heap
+- **Giải phóng khi khởi động** - Giải phóng bộ nhớ khi mở trình duyệt
+- **Điều khiển thủ công** - Giải phóng tab hiện tại/trái/phải/khác
+- **Đóng tab trùng lặp** - Một cú nhấp loại bỏ trùng lặp trong cửa sổ hiện tại
 - **Tìm kiếm tab** - Lọc danh sách tab theo tiêu đề hoặc URL
-- **Nhóm tab** - Unload toàn bộ nhóm tab
-- **Chế độ side panel** - Mở TabRest trong side panel của Chrome (tuỳ chọn)
-- **Snooze tab/site** - Tạm thời bảo vệ tab hoặc domain (30 phút - 2 giờ)
-- **Cảnh báo trước khi unload** - Toast 3 giây cảnh báo trên trang trước khi auto-discard
-- **Chỉ báo trực quan** - Tiền tố tuỳ chỉnh (💤) trên tiêu đề tab đã unload
-- **Whitelist** - Bảo vệ site khỏi auto-unload (hỗ trợ localhost & IP)
-- **Import/Export** - Sao lưu whitelist, blacklist và session ra JSON
-- **Session** - Lưu và khôi phục bộ tab
+- **Nhóm tab** - Giải phóng toàn bộ nhóm tab
+- **Chế độ thanh bên** - Mở TabRest trong thanh bên của Chrome (tuỳ chọn)
+- **Tạm hoãn tab/trang** - Tạm thời bảo vệ tab hoặc domain (30 phút - 2 giờ)
+- **Cảnh báo trước khi giải phóng** - Hiện thông báo 3 giây trên trang trước khi tự động giải phóng
+- **Chỉ báo trực quan** - Tiền tố tuỳ chỉnh (💤) trên tiêu đề tab đã giải phóng
+- **Danh sách trắng** - Bảo vệ trang khỏi tự động giải phóng (hỗ trợ localhost & IP)
+- **Nhập/Xuất** - Sao lưu danh sách trắng, danh sách đen và phiên ra JSON
+- **Phiên làm việc** - Lưu và khôi phục bộ tab
 - **Khôi phục cuộn trang** - Khôi phục vị trí cuộn khi tab tải lại
-- **Timestamp YouTube** - Tiếp tục video tại vị trí cuối sau khi tải lại
-- **Bỏ qua khi offline** - Không discard tab khi mất mạng
-- **Chỉ unload khi nhàn rỗi** - Chỉ auto-unload khi máy tính idle
-- **Power Mode** - Chế độ tiết kiệm pin, bình thường, hoặc hiệu năng cao
-- **Thông báo auto-unload** - Nhận thông báo khi tab được unload
-- **Tooltip bộ nhớ** - Hover thống kê để xem ước tính RAM tiết kiệm trên mỗi tab
-- **Trình hướng dẫn cài đặt** - Wizard nhiều bước tương tác khi mở lần đầu
-- **Báo lỗi tuỳ chọn** - Gửi báo cáo sự cố ẩn danh qua Sentry (mặc định tắt) và form gửi báo lỗi thủ công
-- **Tự mở changelog** - Mở release notes khi cập nhật minor/major
-- **Host permissions tuỳ chọn** - Bảo vệ form chỉ yêu cầu quyền khi bật
-- **Hiển thị RAM** - Phần trăm RAM trực tiếp trên popup
-- **Thống kê** - Theo dõi số tab đã unload và bộ nhớ đã tiết kiệm
+- **Vị trí phát YouTube** - Tiếp tục video tại vị trí cuối sau khi tải lại
+- **Bỏ qua khi offline** - Không giải phóng tab khi mất mạng
+- **Chỉ giải phóng khi nhàn rỗi** - Chỉ tự động giải phóng khi máy tính nhàn rỗi
+- **Chế độ tiết kiệm** - Tiết kiệm pin, bình thường, hoặc hiệu năng cao
+- **Thông báo tự động giải phóng** - Nhận thông báo khi tab được giải phóng
+- **Chú thích bộ nhớ** - Di chuột qua thống kê để xem ước tính RAM tiết kiệm trên mỗi tab
+- **Trình hướng dẫn cài đặt** - Nhiều bước tương tác khi mở lần đầu
+- **Báo lỗi tuỳ chọn** - Gửi báo cáo sự cố ẩn danh qua Sentry (mặc định tắt) và biểu mẫu gửi báo lỗi thủ công
+- **Tự mở changelog** - Mở ghi chú phát hành khi cập nhật minor/major
+- **Quyền truy cập trang tuỳ chọn** - Bảo vệ biểu mẫu chỉ yêu cầu quyền khi bật
+- **Hiển thị RAM** - Phần trăm RAM trực tiếp trên cửa sổ popup
+- **Thống kê** - Theo dõi số tab đã giải phóng và bộ nhớ đã tiết kiệm
 - **Đa ngôn ngữ** - Hỗ trợ 11 ngôn ngữ
 
 ## Phím tắt
 
 | Phím tắt      | Hành động              |
 | ------------- | ---------------------- |
-| `Alt+Shift+D` | Unload tab hiện tại    |
-| `Alt+Shift+O` | Unload các tab khác    |
-| `Alt+Shift+→` | Unload tab bên phải    |
-| `Alt+Shift+←` | Unload tab bên trái    |
+| `Alt+Shift+D` | Giải phóng tab hiện tại |
+| `Alt+Shift+O` | Giải phóng các tab khác |
+| `Alt+Shift+→` | Giải phóng tab bên phải |
+| `Alt+Shift+←` | Giải phóng tab bên trái |
 
 ## Cài đặt
 
@@ -76,7 +76,7 @@
 
 ## Cách hoạt động
 
-TabRest sử dụng API native `chrome.tabs.discard()` của Chrome để unload tab. Tab đã discard:
+TabRest sử dụng API gốc `chrome.tabs.discard()` của Chrome để giải phóng tab. Tab đã giải phóng:
 
 - Vẫn hiển thị trên thanh tab
 - Giữ nguyên vị trí cuộn và dữ liệu form

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -3,22 +3,22 @@
     "message": "TabRest - Rest your tabs, free your RAM"
   },
   "extDescription": {
-    "message": "Cho tab nghỉ ngơi, giải phóng bộ nhớ - tự động dỡ các tab không hoạt động"
+    "message": "Cho tab nghỉ ngơi, giải phóng bộ nhớ - tự động giải phóng các tab không hoạt động"
   },
   "sleeping": {
     "message": "đang ngủ"
   },
   "protected": {
-    "message": "được bảo vệ"
+    "message": "đã bảo vệ"
   },
   "saved": {
     "message": "đã tiết kiệm"
   },
   "unloadOthers": {
-    "message": "Dỡ tab khác"
+    "message": "Giải phóng tab khác"
   },
   "unloadCurrent": {
-    "message": "Dỡ tab hiện tại"
+    "message": "Giải phóng tab hiện tại"
   },
   "tabsInWindow": {
     "message": "Tab trong cửa sổ này"
@@ -36,7 +36,7 @@
     "message": "Thao tác khác"
   },
   "autoUnloadAfter": {
-    "message": "Tự động dỡ sau"
+    "message": "Tự động giải phóng sau"
   },
   "ramThreshold": {
     "message": "Ngưỡng RAM"
@@ -60,10 +60,10 @@
     "message": "Tổng cộng"
   },
   "tabsUnloadedToday": {
-    "message": "Tab đã dỡ hôm nay"
+    "message": "Tab đã giải phóng hôm nay"
   },
   "tabsUnloadedTotal": {
-    "message": "Tổng tab đã dỡ"
+    "message": "Tổng tab đã giải phóng"
   },
   "ramSaved": {
     "message": "RAM tiết kiệm (ước tính)"
@@ -87,10 +87,10 @@
     "message": "Đã xóa phiên"
   },
   "tabUnloaded": {
-    "message": "Đã dỡ tab"
+    "message": "Đã giải phóng tab"
   },
   "tabsUnloaded": {
-    "message": "Đã dỡ $1 tab",
+    "message": "Đã giải phóng $1 tab",
     "placeholders": { "1": { "content": "$1" } }
   },
   "restoredTabs": {
@@ -113,7 +113,7 @@
     "message": "Đã cập nhật ngưỡng"
   },
   "cannotUnloadActive": {
-    "message": "Không thể dỡ tab đang hoạt động"
+    "message": "Không thể giải phóng tab đang hoạt động"
   },
   "failedToSave": {
     "message": "Lưu thất bại"
@@ -140,19 +140,19 @@
     "message": "Hiển thị & thông báo"
   },
   "autoUnload": {
-    "message": "Tự động dỡ"
+    "message": "Tự động giải phóng"
   },
   "unloadOnStartup": {
-    "message": "Dỡ tab khi khởi động trình duyệt"
+    "message": "Giải phóng tab khi khởi động trình duyệt"
   },
   "unloadInactiveAfter": {
-    "message": "Dỡ tab không hoạt động sau:"
+    "message": "Giải phóng tab không hoạt động sau:"
   },
   "memoryManagement": {
     "message": "Quản lý bộ nhớ"
   },
   "unloadWhenRamExceeds": {
-    "message": "Dỡ tab khi RAM vượt quá:"
+    "message": "Giải phóng tab khi RAM vượt quá:"
   },
   "behavior": {
     "message": "Hành vi"
@@ -161,7 +161,7 @@
     "message": "Bao gồm tab đã ghim"
   },
   "showUnloadedCount": {
-    "message": "Hiện số lượng tab đã dỡ trên icon"
+    "message": "Hiện số lượng tab đã giải phóng trên icon"
   },
   "trackStatistics": {
     "message": "Theo dõi thống kê"
@@ -176,10 +176,10 @@
     "message": "Danh sách trắng"
   },
   "whitelistHelp": {
-    "message": "Các trang sẽ không bao giờ bị dỡ tự động"
+    "message": "Các trang sẽ không bao giờ bị tự động giải phóng"
   },
   "memorySaverNoteBody": {
-    "message": "Tính năng Memory Saver tích hợp của Chrome chạy độc lập và vẫn có thể dỡ các trang này."
+    "message": "Tính năng Memory Saver tích hợp của Chrome chạy độc lập và vẫn có thể giải phóng các trang này."
   },
   "learnMoreLink": {
     "message": "Tìm hiểu thêm"
@@ -194,7 +194,7 @@
     "message": "Thống kê"
   },
   "tabsUnloadedLabel": {
-    "message": "Tab đã dỡ"
+    "message": "Tab đã giải phóng"
   },
   "memorySavedLabel": {
     "message": "Bộ nhớ đã tiết kiệm"
@@ -237,19 +237,19 @@
     "message": "Đã đặt lại thống kê"
   },
   "unloadRight": {
-    "message": "Dỡ tab bên phải"
+    "message": "Giải phóng tab bên phải"
   },
   "unloadLeft": {
-    "message": "Dỡ tab bên trái"
+    "message": "Giải phóng tab bên trái"
   },
   "blacklist": {
     "message": "Danh sách đen"
   },
   "blacklistHelp": {
-    "message": "Các trang sẽ luôn bị dỡ tự động (kể cả khi mới hoạt động)"
+    "message": "Các trang sẽ luôn bị tự động giải phóng (kể cả khi mới hoạt động)"
   },
   "enableTabGroups": {
-    "message": "Hiển thị nhóm tab trong popup"
+    "message": "Hiển thị nhóm tab trong cửa sổ popup"
   },
   "tabGroups": {
     "message": "Nhóm tab"
@@ -258,7 +258,7 @@
     "message": "Chọn nhóm tab..."
   },
   "unloadGroup": {
-    "message": "Dỡ nhóm"
+    "message": "Giải phóng nhóm"
   },
   "untitledTabGroup": {
     "message": "Nhóm $ID$",
@@ -270,7 +270,7 @@
     }
   },
   "showDiscardedPrefix": {
-    "message": "Thêm ký hiệu vào tab đã dỡ"
+    "message": "Thêm ký hiệu vào tab đã giải phóng"
   },
   "discardedPrefixLabel": {
     "message": "Ký hiệu:"
@@ -282,7 +282,7 @@
     "message": "Tiền tố tab cần quyền truy cập website. Đã bỏ qua."
   },
   "minTabsLabel": {
-    "message": "Chỉ tự động dỡ khi số tab không hoạt động vượt quá:"
+    "message": "Chỉ tự động giải phóng khi số tab không hoạt động vượt quá:"
   },
   "toolbarAction": {
     "message": "Thao tác thanh công cụ"
@@ -294,16 +294,16 @@
     "message": "Mở popup"
   },
   "actionDiscardCurrent": {
-    "message": "Dỡ tab hiện tại"
+    "message": "Giải phóng tab hiện tại"
   },
   "actionDiscardOthers": {
-    "message": "Dỡ các tab khác"
+    "message": "Giải phóng các tab khác"
   },
   "useSidePanel": {
-    "message": "Mở trong side panel thay vì popup"
+    "message": "Mở trong thanh bên thay vì cửa sổ popup"
   },
   "useSidePanelHelp": {
-    "message": "Side panel giữ mở khi chuyển tab. Yêu cầu Chrome 114+."
+    "message": "Thanh bên giữ mở khi chuyển tab. Yêu cầu Chrome 114+."
   },
   "saveYouTubeTimestamp": {
     "message": "Lưu vị trí phát YouTube"
@@ -312,19 +312,19 @@
     "message": "Tiếp tục video từ vị trí đã lưu khi tab tải lại"
   },
   "onlyDiscardWhenIdle": {
-    "message": "Chỉ tự động dỡ khi máy tính không hoạt động"
+    "message": "Chỉ tự động giải phóng khi máy tính không hoạt động"
   },
   "idleThreshold": {
     "message": "Ngưỡng không hoạt động:"
   },
   "perTabMemoryLabel": {
-    "message": "Dỡ tab sử dụng hơn (JS heap):"
+    "message": "Giải phóng tab sử dụng hơn (JS heap):"
   },
   "perTabMemoryHelp": {
     "message": "Chỉ đo bộ nhớ JavaScript, không phải tổng bộ nhớ tab"
   },
   "powerMode": {
-    "message": "Chế độ nguồn"
+    "message": "Chế độ tiết kiệm"
   },
   "powerModeHelp": {
     "message": "Điều chỉnh mức độ tích cực dựa trên tình trạng nguồn điện"
@@ -351,7 +351,7 @@
     "message": "Bỏ qua khi offline"
   },
   "skipWhenOfflineHelp": {
-    "message": "Không tự động ngủ tab khi mất kết nối mạng"
+    "message": "Không tự động giải phóng tab khi mất kết nối mạng"
   },
   "restoreScrollPosition": {
     "message": "Khôi phục vị trí cuộn"
@@ -381,7 +381,7 @@
     "message": "Mở link ở trạng thái ngủ"
   },
   "notifyOnAutoUnload": {
-    "message": "Thông báo khi tab bị tự động ngủ"
+    "message": "Thông báo khi tab tự động giải phóng"
   },
   "notifyOnAutoUnloadHelp": {
     "message": "Hiển thị thông báo với lý do (hết thời gian/RAM)"
@@ -453,7 +453,7 @@
     "message": "Đã khôi phục tuỳ chọn"
   },
   "showSuspendWarningLabel": {
-    "message": "Hiển thị cảnh báo trước khi tự động tạm dừng"
+    "message": "Hiển thị cảnh báo trước khi tự động giải phóng"
   },
   "showSuspendWarningHelp": {
     "message": "Hiện toast ngắn trên trang để bạn có thể tương tác và giữ tab"
@@ -462,7 +462,7 @@
     "message": "Thời gian cảnh báo:"
   },
   "suspendWarningMessage": {
-    "message": "TabRest sắp tạm dừng tab này để giải phóng bộ nhớ…"
+    "message": "TabRest sắp giải phóng tab này để tiết kiệm bộ nhớ…"
   },
   "exportList": {
     "message": "Xuất"

--- a/docs/vi/chrome-web-store-listing.md
+++ b/docs/vi/chrome-web-store-listing.md
@@ -27,7 +27,7 @@ Mọi cài đặt được lưu cục bộ trên thiết bị của bạn. Báo 
 Tối đa 132 ký tự. Dùng làm tagline cho trang listing.
 
 ```text
-Cho tab nghỉ ngơi, giải phóng bộ nhớ - tự động dỡ các tab không hoạt động giúp Chrome luôn nhanh và phản hồi tốt.
+Cho tab nghỉ ngơi, giải phóng bộ nhớ - tự động giải phóng các tab không hoạt động giúp Chrome luôn nhanh và phản hồi tốt.
 ```
 
 ## Full Description / Mô tả đầy đủ
@@ -80,7 +80,7 @@ TabRest tự động giải phóng bộ nhớ các tab không hoạt động, gi
 • Đóng các tab trùng lặp - một cú nhấp chuột để loại bỏ bản sao
 • Tìm kiếm tab - lọc theo tiêu đề hoặc URL trực tiếp
 • Mẹo vô hạn bộ nhớ - di chuột để xem dự toán bộ nhớ cho từng tab
-• Cảnh báo tạm dừng - cảnh báo 3 giây trước khi tự động giải phóng
+• Cảnh báo trước khi giải phóng - thông báo 3 giây trên trang trước khi tự động giải phóng
 • Giao diện side panel - mở trong thanh bên trình duyệt (luôn hiển thị khi bạn chuyển tab)
 • Xuất/nhập cấu hình - sao lưu và khôi phục danh sách trắng, danh sách đen và phiên làm việc sang JSON clipboard
 • Trình hướng dẫn cài đặt 6 bước - hỗ trợ thiết lập nhanh khi mới cài (có thể chạy lại từ trang Options)

--- a/docs/vi/feature-test-checklist.md
+++ b/docs/vi/feature-test-checklist.md
@@ -34,31 +34,31 @@ Ký hiệu: `[ ]` chưa test · `[x]` đạt · `[!]` lỗi · `[~]` bỏ qua / 
 - [ ] Đặt `Unload after` = 5 phút (Options → Auto-Unload), `Min inactive tabs before discard` = Disabled.
 - [ ] Mở 3 tab (site bất kỳ không nằm trong whitelist). Focus tab A.
 - [ ] Đợi 5 phút trên tab A.
-- [ ] Tab B và C bị discard (favicon mờ, có prefix). Tab A vẫn loaded.
-- [ ] Click tab B đã discard → tải lại tức thì, scroll giữ nguyên (nếu bật `restoreScrollPosition`).
-- [ ] Đặt delay = Disabled → tắt auto-unload; xác nhận tab không còn discard sau 5 phút.
+- [ ] Tab B và C bị giải phóng (favicon mờ, có tiền tố). Tab A vẫn được tải.
+- [ ] Nhấp tab B đã giải phóng → tải lại tức thì, scroll giữ nguyên (nếu bật `restoreScrollPosition`).
+- [ ] Đặt delay = Disabled → tắt auto-unload; xác nhận tab không còn giải phóng sau 5 phút.
 
 ## 2. Auto-Unload - Ngưỡng RAM
 
 - [ ] Đặt `Memory threshold` = 60% (Options → Memory Management).
 - [ ] Mở đủ tab để RAM > 60% (hoặc tạm hạ ngưỡng = RAM hiện tại −5%).
-- [ ] Trong 30s, tab LRU bị discard cho tới khi RAM tụt dưới ngưỡng.
-- [ ] Đặt threshold = 0 → tắt discard theo memory.
+- [ ] Trong 30s, tab LRU bị giải phóng cho tới khi RAM tụt dưới ngưỡng.
+- [ ] Đặt threshold = 0 → tắt giải phóng theo memory.
 
 ## 3. Auto-Unload - Giới hạn JS Heap mỗi tab
 
 - [ ] Đặt `Per-tab JS heap limit` = 100 MB (Options).
 - [ ] Nếu host permission cho form-checker đã cấp trước đó, `chrome.scripting` inject reporter; ngược lại, banner phục hồi xuất hiện trong popup.
 - [ ] Mở site nặng (Figma, Google Sheet lớn) và đợi > 30s.
-- [ ] Tab discard khi heap > 100 MB.
+- [ ] Tab giải phóng khi heap > 100 MB.
 - [ ] Đặt limit = 0 → tắt giám sát heap.
 
 ## 4. Auto-Unload - Khi khởi động
 
 - [ ] Bật `Auto-unload on startup` (Options).
 - [ ] Thoát Chrome rồi mở lại với nhiều tab từ phiên trước.
-- [ ] Mọi tab không active và không trong whitelist bị discard ngay sau khởi động.
-- [ ] Tắt → tab không discard sau khi mở lại.
+- [ ] Mọi tab không hoạt động và không trong danh sách trắng bị giải phóng ngay sau khởi động.
+- [ ] Tắt → tab không giải phóng sau khi mở lại.
 
 ## 5. Ngưỡng số tab inactive tối thiểu
 
@@ -77,8 +77,8 @@ Ký hiệu: `[ ]` chưa test · `[x]` đạt · `[!]` lỗi · `[~]` bỏ qua / 
 
 - [ ] Bật `Skip when offline`.
 - [ ] Ngắt mạng (DevTools → Network → Offline, hoặc tắt Wi-Fi).
-- [ ] Đợi vượt `unloadDelayMinutes` → không tab nào discard.
-- [ ] Kết nối lại → discard tiếp tục ở alarm kế tiếp.
+- [ ] Đợi vượt `unloadDelayMinutes` → không tab nào giải phóng.
+- [ ] Kết nối lại → giải phóng tiếp tục ở alarm kế tiếp.
 
 ## 8. Power Mode
 
@@ -89,28 +89,28 @@ Ký hiệu: `[ ]` chưa test · `[x]` đạt · `[!]` lỗi · `[~]` bỏ qua / 
 
 ## 9. Điều khiển thủ công - Nút trong popup
 
-- [ ] **Unload Current** → discard tab đang focus; popup đóng; tab có prefix.
-- [ ] **Unload Others** → mọi tab khác active đều discard.
-- [ ] **More Actions → Unload Right** → chỉ tab bên phải tab active discard.
+- [ ] **Unload Current** → giải phóng tab đang focus; popup đóng; tab có tiền tố.
+- [ ] **Unload Others** → mọi tab khác đang hoạt động đều giải phóng.
+- [ ] **More Actions → Unload Right** → chỉ tab bên phải tab đang hoạt động giải phóng.
 - [ ] **More Actions → Unload Left** → chỉ tab bên trái.
 - [ ] **More Actions → Close Duplicates** → trong window có ≥ 3 URL trùng, giữ tab cũ nhất, đóng các tab còn lại.
-- [ ] Icon "Unload" mỗi dòng tab discard đúng tab đó.
+- [ ] Biểu tượng "Unload" mỗi dòng tab giải phóng đúng tab đó.
 
 ## 10. Phím tắt
 
 Cấu hình tại `chrome://extensions/shortcuts`.
 
-- [ ] `Alt+Shift+D` - unload tab hiện tại.
-- [ ] `Alt+Shift+O` - unload các tab khác.
-- [ ] `Alt+Shift+→` - unload tab bên phải.
-- [ ] `Alt+Shift+←` - unload tab bên trái.
+- [ ] `Alt+Shift+D` - giải phóng tab hiện tại.
+- [ ] `Alt+Shift+O` - giải phóng các tab khác.
+- [ ] `Alt+Shift+→` - giải phóng tab bên phải.
+- [ ] `Alt+Shift+←` - giải phóng tab bên trái.
 - [ ] Đổi binding một phím tắt → vẫn fire đúng lệnh.
 
 ## 11. Hành động click toolbar
 
 - [ ] `popup` (mặc định) → click icon mở popup.
-- [ ] `discard-current` → click icon discard tab active; không popup.
-- [ ] `discard-others` → click icon discard mọi tab khác.
+- [ ] `discard-current` → nhấp biểu tượng giải phóng tab đang hoạt động; không popup.
+- [ ] `discard-others` → nhấp biểu tượng giải phóng mọi tab khác.
 - [ ] Đổi setting có hiệu lực ngay sau khi lưu Options, không cần reload service worker.
 
 ## 12. Menu chuột phải
@@ -119,7 +119,7 @@ Cấu hình tại `chrome://extensions/shortcuts`.
 - [ ] "Unload this tab" hoạt động.
 - [ ] "Add domain to whitelist" thêm hostname trang đó (gồm localhost hoặc IP).
 - [ ] "Snooze this tab (1h)" + "Snooze this site (1h)" hoạt động.
-- [ ] Right-click trên link → "Open link in suspended state" tạo tab discarded.
+- [ ] Nhấp chuột phải trên liên kết → "Open link in suspended state" tạo tab đã giải phóng.
 
 ## 13. Tìm kiếm tab
 - [ ] Click toggle search trong popup → input xuất hiện và auto focus.
@@ -131,7 +131,7 @@ Cấu hình tại `chrome://extensions/shortcuts`.
 ## 14. Filter Chips
 
 - [ ] **All** hiển thị mọi tab.
-- [ ] **Sleeping** chỉ tab đã discard.
+- [ ] **Sleeping** chỉ tab đã giải phóng.
 - [ ] **Snoozed** tab/domain đang snooze.
 - [ ] **Protected** tab pinned/audio/form/whitelist với badge tương ứng.
 - [ ] Số đếm trên mỗi chip cập nhật trực tiếp khi tab đổi state.
@@ -149,31 +149,31 @@ Cấu hình tại `chrome://extensions/shortcuts`.
 - [ ] Thêm `127.0.0.1` → tab `http://127.0.0.1:*` được bảo vệ.
 - [ ] Thêm `::1` (IPv6) → được bảo vệ.
 - [ ] Nhập sai (ví dụ `http://`) → input báo lỗi, không lưu.
-- [ ] Xóa entry → auto-unload kế tiếp có thể discard domain đó.
+- [ ] Xóa entry → lượt tự động giải phóng kế tiếp có thể giải phóng domain đó.
 - [ ] Context menu "Add to whitelist" trên tab localhost hoặc IP hoạt động trọn vẹn.
 - [ ] Thêm domain đã có trong blacklist → toast báo conflict, không thêm.
 
 ## 17. Blacklist
 
 - [ ] Thêm domain ưu tiên thấp vào blacklist.
-- [ ] Tab thuộc domain đó discard ngay ở timer kế tiếp (bỏ qua delay).
-- [ ] Xóa entry → ngừng discard aggressive.
+- [ ] Tab thuộc domain đó giải phóng ngay ở timer kế tiếp (bỏ qua delay).
+- [ ] Xóa entry → ngừng giải phóng tích cực.
 - [ ] Thêm domain đã có trong whitelist → toast báo conflict, không thêm.
 - [ ] Domain xuất hiện ở cả 2 list (state cũ) → whitelist thắng, tab được bảo vệ.
 
 ## 18. Bảo vệ Pinned / Audio / Form
 
-- [ ] Tab ghim + bật `Protect pinned tabs` → không bao giờ discard qua auto-unload.
-- [ ] Tab ghim + bật `Include pinned tabs` (tức cho phép discard tab ghim) → dòng popup vẫn hiển thị badge "pin" (intrinsic) và filter chip "protected" vẫn count.
-- [ ] Tab phát YouTube + `Protect audio tabs` → không discard.
-- [ ] Tab có form chưa lưu (ví dụ Google Form điền dở) + `Protect form tabs` → không discard; dòng popup hiển thị badge "Form".
-- [ ] Tab có form chưa lưu trên React/contenteditable editor (ví dụ body issue GitHub) → sau khi gõ, dòng popup hiển thị badge "Form" (eager-injection bắt được keystroke).
+- [ ] Tab ghim + bật `Protect pinned tabs` → không bao giờ giải phóng qua auto-unload.
+- [ ] Tab ghim + bật `Include pinned tabs` (tức cho phép giải phóng tab ghim) → dòng popup vẫn hiển thị badge "pin" (intrinsic) và filter chip "protected" vẫn count.
+- [ ] Tab phát YouTube + `Protect audio tabs` → không giải phóng.
+- [ ] Tab có biểu mẫu chưa lưu (ví dụ Google Form điền dở) + `Protect form tabs` → không giải phóng; dòng popup hiển thị badge "Form".
+- [ ] Tab có biểu mẫu chưa lưu trên React/contenteditable editor (ví dụ body issue GitHub) → sau khi gõ, dòng popup hiển thị badge "Form" (eager-injection bắt được keystroke).
 - [ ] Tab vừa whitelist vừa pin/audio/form → popup ưu tiên badge cụ thể (pin/audio/form), không hiển thị "safe" - whitelist là priority thấp nhất.
 - [ ] Tắt một protection → tab khớp trở lại đủ điều kiện.
 - [ ] **Force unload** (menu mỗi tab trong popup) override mọi protection.
 
 ## 19. Optional Host Permissions + Form Injector
-- [ ] Cài mới: host permissions KHÔNG cấp mặc định.
+- [ ] Cài mới: quyền truy cập trang KHÔNG cấp mặc định.
 - [ ] Tắt rồi bật `Protect form tabs` → prompt cấp quyền hoặc banner phục hồi xuất hiện.
 - [ ] Cấp quyền → form-checker eager-inject mỗi khi page load (và lazy-inject với tab đã mở sẵn ở lần check đầu); xác nhận qua badge popup và `window.__tabrestFormCheckLoaded` trong DevTools.
 - [ ] Thu hồi qua `chrome://extensions` → banner phục hồi tái xuất trong popup với CTA "Enable".
@@ -181,65 +181,65 @@ Cấu hình tại `chrome://extensions/shortcuts`.
 
 ## 20. Snooze
 
-- [ ] Snooze tab 30 phút → hiển thị badge "Snoozed"; auto-unload bỏ qua.
-- [ ] Snooze domain 1 giờ → mọi tab hiện tại và mới của domain được bảo vệ.
-- [ ] Hủy snooze → tab/domain trở lại đủ điều kiện.
-- [ ] Snooze giữ qua khởi động lại trình duyệt (trong cùng window).
-- [ ] Snooze tự hết hạn khi timer kết thúc.
+- [ ] Tạm hoãn tab 30 phút → hiển thị badge "Snoozed"; auto-unload bỏ qua.
+- [ ] Tạm hoãn domain 1 giờ → mọi tab hiện tại và mới của domain được bảo vệ.
+- [ ] Hủy tạm hoãn → tab/domain trở lại đủ điều kiện.
+- [ ] Tạm hoãn giữ qua khởi động lại trình duyệt (trong cùng window).
+- [ ] Tạm hoãn tự hết hạn khi timer kết thúc.
 
 ## 21. Cảnh báo trước khi suspend
 - [ ] Bật `Show suspend warning`; delay = 3000 ms.
 - [ ] Mở một tab và để nó đủ điều kiện auto-unload.
-- [ ] Toast xuất hiện trong trang 3 s trước khi discard.
+- [ ] Thông báo xuất hiện trên trang 3 s trước khi giải phóng.
 - [ ] Chuyển sang tab → hủy discard.
-- [ ] Bật audio/video, sửa form, hoặc snooze trong 3 s cũng hủy được.
-- [ ] Tắt setting → không có toast; tab discard im lặng.
+- [ ] Bật âm thanh/video, sửa biểu mẫu, hoặc tạm hoãn trong 3 s cũng hủy được.
+- [ ] Tắt setting → không có thông báo; tab giải phóng im lặng.
 - [ ] Delay tùy chỉnh (ví dụ 5000 ms) được tôn trọng.
 
 ## 22. Khôi phục thời điểm YouTube
 
 - [ ] Bật `Save YouTube timestamp`.
-- [ ] Phát video YouTube đến 1:00 rồi unload tab.
-- [ ] Reload tab đã discard → playback tiếp tục từ ≥ 0:55.
+- [ ] Phát video YouTube đến 1:00 rồi giải phóng tab.
+- [ ] Tải lại tab đã giải phóng → playback tiếp tục từ ≥ 0:55.
 - [ ] Sau > 7 ngày → cache hết hạn (kiểm tra thủ công: chỉnh `chrome.storage.sync`).
 
 ## 23. Khôi phục vị trí cuộn
 
 - [ ] Bật `Restore scroll position`.
-- [ ] Cuộn nửa trang dài rồi để tab discard.
+- [ ] Cuộn nửa trang dài rồi để tab giải phóng.
 - [ ] Mở lại tab → khôi phục trong khoảng ±50 px so với vị trí gốc.
-- [ ] Giới hạn 100 entry: discard 110 tab khác nhau và xác nhận entry cũ bị loại khỏi `tabrest_scroll_positions` (chrome.storage.local).
+- [ ] Giới hạn 100 entry: giải phóng 110 tab khác nhau và xác nhận entry cũ bị loại khỏi `tabrest_scroll_positions` (chrome.storage.local).
 
 ## 24. Tab Groups
 
 - [ ] Tạo group có 3 tab.
 - [ ] Selector `Tab groups` trong popup hiển thị group với số tab.
-- [ ] "Unload this group" discard mọi tab trong group, giữ nguyên cấu trúc.
+- [ ] "Unload this group" giải phóng mọi tab trong group, giữ nguyên cấu trúc.
 - [ ] Tắt `Enable tab groups` → ẩn selector.
 - [ ] Đa cửa sổ: mở 2 cửa sổ với group khác nhau → popup mỗi cửa sổ chỉ liệt kê group của chính nó.
 - [ ] Side panel: khi panel đang mở, tạo/đổi tên/xoá group → selector tự cập nhật, không cần đóng-mở.
 
 ## 25. Chỉ báo trực quan
 
-- [ ] Badge count = số tab discarded (toggle `Show badge count`).
-- [ ] Title prefix dùng glyph cấu hình (mặc định `💤`); glyph tùy chỉnh (≤ 4 ký tự) lưu và áp dụng sau prompt host permission.
-- [ ] Tắt prefix → title không thay đổi ở lần discard kế tiếp.
+- [ ] Badge count = số tab đã giải phóng (toggle `Show badge count`).
+- [ ] Tiền tố tiêu đề dùng glyph cấu hình (mặc định `💤`); glyph tùy chỉnh (≤ 4 ký tự) lưu và áp dụng sau prompt host permission.
+- [ ] Tắt tiền tố → tiêu đề không thay đổi ở lần giải phóng kế tiếp.
 - [ ] RAM % header popup cập nhật mỗi ~5 s.
 
 ## 26. Tooltip ước lượng RAM
-- [ ] Hover stats RAM trong popup → tooltip giải thích ước lượng (ví dụ "~150 MB mỗi tab discarded").
+- [ ] Di chuột qua stats RAM trong popup → tooltip giải thích ước lượng (ví dụ "~150 MB mỗi tab đã giải phóng").
 - [ ] Text tooltip có bản `vi`.
 - [ ] Tooltip biến mất khi rời chuột.
 
 ## 27. Notifications
 
 - [ ] Bật `Notify on auto-unload`.
-- [ ] Trigger auto-unload → notification desktop với số tab + RAM tiết kiệm.
+- [ ] Trigger tự động giải phóng → thông báo desktop với số tab + RAM tiết kiệm.
 - [ ] Notification tôn trọng OS focus-assist / Do Not Disturb.
 
 ## 28. Thống kê
 
-- [ ] Sau khi unload vài tab, popup `Stats` hiển thị đúng tổng hôm nay + tổng thời gian.
+- [ ] Sau khi giải phóng vài tab, popup `Stats` hiển thị đúng tổng hôm nay + tổng thời gian.
 - [ ] Ước lượng "RAM saved" tăng.
 - [ ] "Member since" phản ánh ngày cài đặt.
 - [ ] "Reset stats" về 0 và xác nhận qua toast.
@@ -310,7 +310,7 @@ Cho từng loại: **whitelist**, **blacklist**, **sessions**:
 
 - [ ] Đăng nhập Chrome với tài khoản có sync.
 - [ ] Sửa setting trên Profile A; trên Profile B (cùng tài khoản) xác nhận sync trong ~1 phút.
-- [ ] Sessions và whitelist truyền giữa các thiết bị (sessions lưu trong `chrome.storage.sync`).
+- [ ] Phiên làm việc và danh sách trắng truyền giữa các thiết bị (sessions lưu trong `chrome.storage.sync`).
 - [ ] Tab activity giữ riêng từng máy (`chrome.storage.local`).
 
 ## 38. Độ bền Service Worker

--- a/docs/vi/unload-decision-matrix.md
+++ b/docs/vi/unload-decision-matrix.md
@@ -1,36 +1,36 @@
-# Ma Trận Quyết Định Unload
+# Ma Trận Quyết Định Giải Phóng Tab
 
-Cách TabRest quyết định khi nào unload tab.
+Cách TabRest quyết định khi nào giải phóng tab.
 
 ## Triggers
 
 | Trigger          | Tần suất    | Mục đích                                                        |
 | ---------------- | ----------- | --------------------------------------------------------------- |
-| **Timer**        | Mỗi 1 phút  | Unload tab không hoạt động quá `unloadDelayMinutes`             |
-| **Memory**       | Mỗi 30 giây | Unload tab LRU khi RAM vượt `memoryThresholdPercent`            |
-| **Per-tab Heap** | Mỗi 30 giây | Unload tab có JS heap vượt `perTabJsHeapThresholdMB`            |
-| **Blacklist**    | Cùng Timer  | Unload ngay lập tức các tab khớp với domain trong danh sách đen |
+| **Timer**        | Mỗi 1 phút  | Giải phóng tab không hoạt động quá `unloadDelayMinutes`         |
+| **Memory**       | Mỗi 30 giây | Giải phóng tab LRU khi RAM vượt `memoryThresholdPercent`        |
+| **Per-tab Heap** | Mỗi 30 giây | Giải phóng tab có JS heap vượt `perTabJsHeapThresholdMB`        |
+| **Blacklist**    | Cùng Timer  | Giải phóng ngay lập tức các tab khớp với domain trong danh sách đen |
 
 ## Ma Trận Bảo Vệ
 
 | Bảo vệ                  | Timer | Memory | Per-tab Heap | Blacklist |
 | ----------------------- | :---: | :----: | :----------: | :-------: |
-| Tab đang active         |  Có   |   Có   |      Có      |    Có     |
-| Đã discarded            |  Có   |   Có   |      Có      |    Có     |
-| Đang snooze             |  Có   |   Có   |      Có      |    Có     |
-| Pinned (nếu bật)        |  Có   |   Có   |      Có      |    Có     |
-| Whitelist               |  Có   |   Có   |      Có      |    Có     |
+| Tab đang hoạt động      |  Có   |   Có   |      Có      |    Có     |
+| Đã giải phóng           |  Có   |   Có   |      Có      |    Có     |
+| Đang tạm hoãn           |  Có   |   Có   |      Có      |    Có     |
+| Đã ghim (nếu bật)       |  Có   |   Có   |      Có      |    Có     |
+| Danh sách trắng         |  Có   |   Có   |      Có      |    Có     |
 | Đang phát âm thanh      |  Có   |   Có   |      Có      |    Có     |
-| Form chưa lưu           |  Có   |   Có   |      Có      |    Có     |
+| Biểu mẫu chưa lưu       |  Có   |   Có   |      Có      |    Có     |
 | Bỏ qua khi offline      |  Có   |   Có   |      Có      |    Có     |
-| Chỉ khi idle            |  Có   | Không  |    Không     |   Không   |
+| Chỉ khi nhàn rỗi        |  Có   | Không  |    Không     |   Không   |
 | Ngưỡng số tab tối thiểu |  Có   | Không  |    Không     |   Không   |
 
-**Ghi chú:** Idle-only và Min tabs threshold chỉ áp dụng cho Timer:
+**Ghi chú:** Chỉ-khi-nhàn-rỗi và Ngưỡng số tab tối thiểu chỉ áp dụng cho Timer:
 
 | Bảo vệ            | Tại sao chỉ Timer?                                                            |
 | ----------------- | ----------------------------------------------------------------------------- |
-| **Chỉ khi idle**  | Memory là trường hợp khẩn cấp - đợi idle có thể gây treo hệ thống nếu RAM đầy |
+| **Chỉ khi nhàn rỗi** | Memory là trường hợp khẩn cấp - đợi nhàn rỗi có thể gây treo hệ thống nếu RAM đầy |
 | **Ngưỡng số tab** | Memory pressure cần giải phóng ngay, không quan tâm số lượng tab              |
 
 Timer = tiện lợi (không gấp), Memory/Heap = khẩn cấp (cần xử lý ngay để tránh crash).
@@ -38,24 +38,24 @@ Timer = tiện lợi (không gấp), Memory/Heap = khẩn cấp (cần xử lý 
 ## Thứ Tự Ưu Tiên Bảo Vệ
 
 ```
-1. TUYỆT ĐỐI (không bao giờ unload)
-   - Tab đang active
-   - Đã discarded
+1. TUYỆT ĐỐI (không bao giờ giải phóng)
+   - Tab đang hoạt động
+   - Đã giải phóng
 
 2. BẢO VỆ RÕ RÀNG TỪ USER
-   - Tab/domain đang snooze
+   - Tab/domain đang tạm hoãn
 
 3. BẢO VỆ DỮ LIỆU
-   - Form chưa lưu
-   - Chế độ offline (tab không thể reload)
+   - Biểu mẫu chưa lưu
+   - Chế độ offline (tab không thể tải lại)
 
 4. BẢO VỆ TRẢI NGHIỆM
    - Đang phát âm thanh
-   - Domain trong whitelist
-   - Tab pinned
+   - Domain trong danh sách trắng
+   - Tab đã ghim
 
 5. CÓ ĐIỀU KIỆN (chỉ Timer)
-   - Kiểm tra idle-only
+   - Kiểm tra chỉ-khi-nhàn-rỗi
    - Ngưỡng số tab tối thiểu
 ```
 
@@ -67,38 +67,38 @@ Trigger đến (Timer/Memory/Heap/Blacklist)
                 ▼
 ┌───────────────────────────────┐
 │ KIỂM TRA TUYỆT ĐỐI (tất cả)   │
-│ • Active? → BỎ QUA            │
-│ • Discarded? → BỎ QUA         │
-│ • Snoozed? → BỎ QUA           │
+│ • Đang hoạt động? → BỎ QUA    │
+│ • Đã giải phóng? → BỎ QUA     │
+│ • Đang tạm hoãn? → BỎ QUA     │
 └───────────────────────────────┘
                 │
                 ▼
 ┌───────────────────────────────┐
 │ BẢO VỆ DỮ LIỆU (tất cả)       │
-│ • Form chưa lưu? → BỎ QUA     │
+│ • Biểu mẫu chưa lưu? → BỎ QUA │
 │ • Offline? → BỎ QUA           │
 └───────────────────────────────┘
                 │
                 ▼
 ┌───────────────────────────────┐
 │ TRẢI NGHIỆM (tất cả)          │
-│ • Đang phát audio? → BỎ QUA   │
-│ • Trong whitelist? → BỎ QUA   │
-│ • Pinned (bảo vệ)? → BỎ QUA   │
+│ • Đang phát âm thanh? → BỎ QUA│
+│ • Trong danh sách trắng? → BỎ QUA│
+│ • Đã ghim (bảo vệ)? → BỎ QUA  │
 └───────────────────────────────┘
                 │
                 ▼
 ┌───────────────────────────────┐
 │ CÓ ĐIỀU KIỆN (chỉ Timer)      │
-│ • User không idle? → BỎ QUA   │
-│ • Dưới minTabs? → BỎ QUA      │
+│ • Không nhàn rỗi? → BỎ QUA    │
+│ • Dưới ngưỡng số tab? → BỎ QUA│
 └───────────────────────────────┘
                 │
                 ▼
-          ✓ UNLOAD TAB
+          ✓ GIẢI PHÓNG TAB
 ```
 
-## Chế Độ Power
+## Chế Độ Tiết Kiệm
 
 | Chế độ        | Hệ số delay            | Offset ngưỡng Memory   |
 | ------------- | ---------------------- | ---------------------- |
@@ -108,12 +108,12 @@ Trigger đến (Timer/Memory/Heap/Blacklist)
 
 ## Cùng Tồn Tại Với Chrome Memory Saver
 
-Chrome có sẵn cơ chế discard tab riêng (Memory Saver, `chrome://settings/performance`, từ Chrome 108). Cơ chế này chạy ở tầng trình duyệt và **không** tham khảo bất kỳ extension nào, kể cả TabRest.
+Chrome có sẵn cơ chế giải phóng tab riêng (Memory Saver, `chrome://settings/performance`, từ Chrome 108). Cơ chế này chạy ở tầng trình duyệt và **không** tham khảo bất kỳ extension nào, kể cả TabRest.
 
 ### Điều này nghĩa là gì trong thực tế
 
-- Whitelist và snooze là cờ của TabRest lưu trong `chrome.storage`. Chúng ngăn **TabRest** discard một tab. Chúng **không** ngăn được **Chrome Memory Saver** discard cùng tab đó.
-- Chrome Memory Saver chỉ tôn trọng các điều kiện riêng của nó: tab đang phát audio, đang dùng camera/mic, có form chưa lưu, đã pin, hoặc nằm trong danh sách "Always keep these sites active" của Chrome.
+- Danh sách trắng và tạm hoãn là cờ của TabRest lưu trong `chrome.storage`. Chúng ngăn **TabRest** giải phóng một tab. Chúng **không** ngăn được **Chrome Memory Saver** giải phóng cùng tab đó.
+- Chrome Memory Saver chỉ tôn trọng các điều kiện riêng của nó: tab đang phát âm thanh, đang dùng camera/mic, có biểu mẫu chưa lưu, đã ghim, hoặc nằm trong danh sách "Always keep these sites active" của Chrome.
 - Không có Chrome Extension API nào cho phép loại trừ một tab khỏi Memory Saver.
 
 ### Các thiết lập khuyến nghị cho user
@@ -122,6 +122,6 @@ Chrome có sẵn cơ chế discard tab riêng (Memory Saver, `chrome://settings/
 | ------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
 | Tắt Chrome Memory Saver, chỉ dùng TabRest                                                                                | Hành vi sạch nhất; toàn quyền kiểm soát qua cài đặt TabRest          |
 | Giữ Chrome Memory Saver bật VÀ duplicate các domain quan trọng vào danh sách "Always keep these sites active" của Chrome | Hai hệ thống cùng chạy; user phải duy trì hai danh sách              |
-| Giữ Chrome Memory Saver bật mà không duplicate                                                                           | Whitelist/snooze trông như "hỏng" với những tab Chrome quyết discard |
+| Giữ Chrome Memory Saver bật mà không duplicate                                                                           | Danh sách trắng / tạm hoãn trông như "hỏng" với những tab Chrome quyết giải phóng |
 
 Đây là giới hạn của nền tảng Chrome, không phải giới hạn của TabRest.

--- a/website/src/content/docs/vi/faq.mdx
+++ b/website/src/content/docs/vi/faq.mdx
@@ -184,7 +184,7 @@ TabRest nên hoạt động trên trình duyệt dựa trên Chromium hỗ trợ
 
 **Ghi chú**: Chỉ ảnh hưởng cửa sổ hiện tại, không phải các cửa sổ khác.
 
-### Làm sao sao lưu whitelist hoặc sessions?
+### Làm sao sao lưu danh sách trắng hoặc phiên?
 
 1. Mở **popup TabRest**
 2. Kéo xuống phần **Sessions** hoặc **More Actions**
@@ -201,7 +201,7 @@ Cảnh báo suspend là một thông báo trên trang web xuất hiện **3 giâ
 - **Mục đích**: Cho bạn cơ hội ngăn chặn (tương tác với tab hoặc chuyển hướng)
 - **Bật/Tắt**: Cài đặt → Behavior → "Show suspend warning"
 - **Tùy chỉnh**: Thay đổi độ trễ (ms) trong **Suspend warning delay**
-- **Hành vi**: Nếu bạn nhấp, nhập, hoặc phát audio, cảnh báo sẽ bị hủy
+- **Hành vi**: Nếu bạn nhấp, nhập, hoặc phát âm thanh, cảnh báo sẽ bị hủy
 
 ### TabRest có thể tự động giải phóng tab khi số tab đạt X không?
 
@@ -274,14 +274,14 @@ TabRest nên hoạt động cùng các tiện ích quản lý tab khác, nhưng:
 Từ Chrome 108, Chrome có sẵn **Memory Saver** tại `chrome://settings/performance`, tự động giải phóng tab không hoạt động ở cấp trình duyệt. TabRest và Memory Saver chạy độc lập:
 
 - **Memory Saver không tham khảo TabRest**. Không có Chrome Extension API nào cho phép loại trừ một tab khỏi Memory Saver.
-- **Danh sách trắng và snooze của TabRest chỉ áp dụng cho cơ chế giải phóng của TabRest**. Chúng không ngăn được Chrome tự giải phóng cùng tab đó.
+- **Danh sách trắng và tạm hoãn của TabRest chỉ áp dụng cho cơ chế giải phóng của TabRest**. Chúng không ngăn được Chrome tự giải phóng cùng tab đó.
 
 **Nếu bật cả hai**, một tab trong danh sách trắng vẫn có thể bị Chrome giải phóng. Để tránh điều này, hãy chọn một trong hai cách:
 
 1. Tắt Chrome Memory Saver và để TabRest quản lý hoàn toàn (khuyến nghị cho người dùng muốn kiểm soát chi tiết), hoặc
 2. Giữ cả hai bật, đồng thời thêm các domain quan trọng vào danh sách **Always keep these sites active** của Chrome tại `chrome://settings/performance`
 
-Xem [Cấu hình danh sách trắng](/vi/docs/whitelist-config#cùng-tồn-tại-với-chrome-memory-saver) để biết chi tiết.
+Xem [Cấu hình danh sách trắng](/vi/docs/whitelist-config#cung-ton-tai-voi-chrome-memory-saver) để biết chi tiết.
 
 ### Tại sao tab trong danh sách trắng vẫn bị giải phóng?
 
@@ -293,7 +293,7 @@ Các nguyên nhân khác có thể có:
 - Đang bật chế độ blacklist (danh sách trắng trở thành danh sách giải phóng)
 - Có tiện ích quản lý tab khác cũng được cài đặt
 
-Xem [Xử lý sự cố -> Danh sách trắng không hoạt động](/vi/docs/troubleshooting#danh-sách-trắng-không-hoạt-động) để biết các bước chẩn đoán đầy đủ.
+Xem [Xử lý sự cố -> Danh sách trắng không hoạt động](/vi/docs/troubleshooting#danh-sach-trang-khong-hoat-dong) để biết các bước chẩn đoán đầy đủ.
 
 ## Xử lý sự cố
 
@@ -332,7 +332,7 @@ Không trực tiếp từ UI. Cài đặt được lưu trong `chrome.storage.sy
 
 ### Làm sao để báo cáo lỗi?
 
-Xem [Khắc phục sự cố → Báo cáo lỗi](/vi/docs/troubleshooting#báo-cáo-lỗi) để biết hướng dẫn chi tiết.
+Xem [Khắc phục sự cố → Báo cáo lỗi](/vi/docs/troubleshooting#bao-cao-loi) để biết hướng dẫn chi tiết.
 
 ## Bắt đầu
 

--- a/website/src/content/docs/vi/features.mdx
+++ b/website/src/content/docs/vi/features.mdx
@@ -25,7 +25,7 @@ Tự động giải phóng tab sau thời gian không hoạt động:
 | 2 giờ    | Giữ tab lâu hơn |
 | 4 giờ    | Tự động giải phóng tối thiểu |
 
-**Cách hoạt động**: TabRest theo dõi lần tương tác cuối cùng với mỗi tab (click, cuộn, focus). Sau thời gian cấu hình, các tab không hoạt động sẽ được giải phóng.
+**Cách hoạt động**: TabRest theo dõi lần tương tác cuối cùng với mỗi tab (nhấp, cuộn, focus). Sau thời gian cấu hình, các tab không hoạt động sẽ được giải phóng.
 
 ### Giải phóng theo ngưỡng bộ nhớ
 
@@ -85,11 +85,11 @@ Ngăn tab bị giải phóng khi mất kết nối mạng:
 
 ### Cảnh báo trước khi suspend
 
-Nhận cảnh báo (toast) trên trang web trước khi tab bị tự động giải phóng:
+Nhận cảnh báo trên trang web trước khi tab bị tự động giải phóng:
 
 - **Mặc định**: Bật
 - **Khoảng thời gian**: 3 giây cảnh báo trước khi giải phóng
-- **Hành vi**: Nếu bạn tương tác với tab (click, nhập, phát audio) thì cảnh báo sẽ bị hủy
+- **Hành vi**: Nếu bạn tương tác với tab (nhấp, nhập, phát âm thanh) thì cảnh báo sẽ bị hủy
 - **Có thể tùy chỉnh**: Thay đổi độ trễ (ms) trong Cài đặt
 - **Trường hợp sử dụng**: Tránh mất bất ngờ tab mà không biết
 
@@ -135,9 +135,9 @@ Tùy chỉnh hành động khi nhấp vào biểu tượng tiện ích:
 | **Giải phóng tab hiện tại** | Giải phóng tab hiện tại ngay lập tức |
 | **Giải phóng các tab khác** | Giải phóng tất cả tab khác ngay lập tức |
 
-**Trường hợp sử dụng**: Người dùng nâng cao muốn giải phóng một click mà không mở popup.
+**Trường hợp sử dụng**: Người dùng nâng cao muốn giải phóng một nhấp mà không mở popup.
 
-## Chế độ nguồn
+## Chế độ tiết kiệm
 
 Điều chỉnh mức độ tích cực tự động giải phóng dựa trên tình huống:
 
@@ -160,15 +160,15 @@ Bảo vệ các tab cụ thể khỏi tự động giải phóng:
 - **Mặc định**: Được bảo vệ khỏi tự động giải phóng
 - **Có thể cấu hình**: Bật "Giải phóng tab ghim" trong cài đặt để ghi đè
 
-### Tab Audio/Video
+### Tab Âm thanh/Video
 - **Mặc định**: Được bảo vệ khi đang phát media
 - **Phát hiện**: Kiểm tra thuộc tính `tab.audible`
-- **Có thể cấu hình**: Tắt "Bảo vệ tab đang phát audio/video" để cho phép giải phóng
+- **Có thể cấu hình**: Tắt "Bảo vệ tab đang phát âm thanh/video" để cho phép giải phóng
 
-### Tab Form
-- **Mặc định**: Được bảo vệ khi form có dữ liệu chưa lưu
+### Tab Biểu mẫu
+- **Mặc định**: Được bảo vệ khi biểu mẫu có dữ liệu chưa lưu
 - **Phát hiện**: Content script kiểm tra các trường input đã thay đổi
-- **Có thể cấu hình**: Tắt "Bảo vệ tab có form chưa lưu" để cho phép giải phóng
+- **Có thể cấu hình**: Tắt "Bảo vệ tab có biểu mẫu chưa lưu" để cho phép giải phóng
 
 ### Danh sách trắng
 - **Mặc định**: YouTube, Gmail, Google Docs, Miro, Figma, Notion
@@ -223,7 +223,7 @@ Xem mức sử dụng RAM hệ thống trong header popup:
 
 - **Hiển thị**: Hiện % RAM cùng với thống kê tab
 - **Cảnh báo**: Làm nổi bật khi RAM vượt ngưỡng đã cấu hình
-- **Tooltip**: Di chuột để xem ước tính bộ nhớ được giải phóng (~150 MB mỗi tab)
+- **Chú thích**: Di chuột qua để xem ước tính bộ nhớ được giải phóng (~150 MB mỗi tab)
 - **Ước tính**: Hiển thị xấp xỉ bao nhiêu bộ nhớ có thể được giải phóng nếu các tab đang ngủ được tải lại
 
 ## Khôi phục vị trí cuộn
@@ -246,13 +246,13 @@ Nhận thông báo khi tab bị tự động giải phóng:
 
 **Trường hợp sử dụng**: Theo dõi những gì TabRest đang làm trong nền.
 
-## Mở link ở trạng thái ngủ
+## Mở liên kết ở trạng thái ngủ
 
-Mở link trực tiếp ở trạng thái đã giải phóng:
+Mở liên kết trực tiếp ở trạng thái đã giải phóng:
 
-- **Truy cập**: Nhấn chuột phải lên link → "Mở link ở trạng thái ngủ"
+- **Truy cập**: Nhấn chuột phải lên liên kết → "Mở liên kết ở trạng thái ngủ"
 - **Hành vi**: Tạo tab, đợi tải xong, rồi giải phóng ngay
-- **Trường hợp sử dụng**: Lưu link để đọc sau mà không tốn bộ nhớ
+- **Trường hợp sử dụng**: Lưu liên kết để đọc sau mà không tốn bộ nhớ
 
 ## Side Panel (Bảng bên)
 

--- a/website/src/content/docs/vi/getting-started.mdx
+++ b/website/src/content/docs/vi/getting-started.mdx
@@ -54,7 +54,7 @@ Sau khi cài đặt, TabRest hoạt động ngay với cài đặt mặc định
 
 - **Hẹn giờ tự động giải phóng**: 30 phút không hoạt động
 - **Ngưỡng bộ nhớ**: 80% RAM
-- **Tab được bảo vệ**: Tab ghim, tab có audio, tab có form chưa lưu
+- **Tab được bảo vệ**: Tab ghim, tab có âm thanh, tab có biểu mẫu chưa lưu
 - **Danh sách trắng**: YouTube, Gmail, Google Docs (cấu hình sẵn)
 
 ### Cấu hình nhanh

--- a/website/src/content/docs/vi/privacy-policy.mdx
+++ b/website/src/content/docs/vi/privacy-policy.mdx
@@ -34,7 +34,7 @@ TabRest tách biệt hành vi thành hai chế độ. Mặc định, tiện ích
 | Báo cáo crash | ❌ Không bao giờ | ✅ Tên lỗi, message, stack trace đã làm sạch |
 | Thông tin thiết bị/môi trường | ❌ Không bao giờ | ✅ Phiên bản extension, browser + OS string |
 | Bộ đếm tổng hợp | ❌ Không bao giờ | ✅ Tab counts (tổng/discarded/pinned/audible), RAM stats, settings, ngày cài đặt |
-| Nội dung whitelist / blacklist | ❌ Không bao giờ | ❌ Loại trừ - chỉ gửi số lượng entry |
+| Nội dung danh sách trắng / danh sách đen | ❌ Không bao giờ | ❌ Loại trừ - chỉ gửi số lượng entry |
 
 Báo cáo lỗi opt-in được mô tả đầy đủ trong [Báo cáo lỗi](#error-reporting). Bạn có thể tắt bất cứ lúc nào tại Tùy chọn → Privacy & Diagnostics.
 
@@ -60,7 +60,7 @@ TabRest yêu cầu các quyền sau:
 **Thực tế làm gì**:
 
 - Đọc URL tab để khớp với danh sách trắng
-- Đọc trạng thái tab (ghim, audio, hoạt động)
+- Đọc trạng thái tab (ghim, âm thanh, hoạt động)
 - Gọi `chrome.tabs.discard()` để giải phóng tab
 
 **Thực tế KHÔNG làm gì**:
@@ -128,10 +128,10 @@ TabRest yêu cầu các quyền sau:
 
 TabRest yêu cầu quyền **tùy chọn** cho một số tính năng. Bạn có toàn quyền kiểm soát:
 
-### `http://*/*` và `https://*/*` - Kiểm tra form chưa lưu
+### `http://*/*` và `https://*/*` - Kiểm tra biểu mẫu chưa lưu
 
 **Khi cần**:
-- Bật "Bảo vệ tab với form chưa lưu" trong Cài đặt
+- Bật "Bảo vệ tab với biểu mẫu chưa lưu" trong Cài đặt
 - Bật tính năng "Prepend symbol to discarded tabs" (thêm ký hiệu vào tab đã giải phóng)
 
 **Làm gì**:
@@ -140,7 +140,7 @@ TabRest yêu cầu quyền **tùy chọn** cho một số tính năng. Bạn có
 
 **Bạn có thể**:
 - Tắt tính năng bất kỳ lúc nào → quyền sẽ được gỡ bỏ
-- Chọn từ chối quyền → tính năng vẫn hoạt động nhưng form protection bị vô hiệu
+- Chọn từ chối quyền → tính năng vẫn hoạt động nhưng bảo vệ biểu mẫu bị vô hiệu
 
 **Ghi chú**: Quyền này là **tùy chọn** - bạn chỉ cấp nó khi cần tính năng.
 
@@ -232,15 +232,15 @@ TabRest có thể gửi báo cáo lỗi ẩn danh để giúp sửa lỗi nhanh 
 
 - Tên lỗi, thông báo và stack trace đã làm sạch (URL, địa chỉ email và IP thay bằng `[REDACTED]`)
 - Phiên bản tiện ích, tên và phiên bản trình duyệt, chuỗi nền tảng hệ điều hành
-- Số lượng tab: tổng, đã dỡ, đã ghim, đang phát âm thanh, số cửa sổ - không gửi URL hay tiêu đề trang
+- Số lượng tab: tổng, đã giải phóng, đã ghim, đang phát âm thanh, số cửa sổ - không gửi URL hay tiêu đề trang
 - Thống kê bộ nhớ hệ thống: phần trăm sử dụng, tổng RAM, RAM khả dụng
-- Giá trị cài đặt (hẹn giờ tự động dỡ, ngưỡng RAM, các tuỳ chọn tính năng, v.v.) - danh sách trắng và danh sách đen **không được gửi**; chỉ gửi số lượng mục
-- Thống kê tích lũy: tổng tab đã dỡ và số hôm nay, ngày cài đặt
+- Giá trị cài đặt (hẹn giờ tự động giải phóng, ngưỡng RAM, các tuỳ chọn tính năng, v.v.) - danh sách trắng và danh sách đen **không được gửi**; chỉ gửi số lượng mục
+- Thống kê tích lũy: tổng tab đã giải phóng và số hôm nay, ngày cài đặt
 
 **Dữ liệu KHÔNG BAO GIỜ gửi:**
 
 - URL các trang bạn truy cập
-- Tiêu đề trang, nội dung, dữ liệu form hay vị trí cuộn
+- Tiêu đề trang, nội dung, dữ liệu biểu mẫu hay vị trí cuộn
 - Địa chỉ email hoặc IP (đã xóa ở phía client trước khi gửi)
 - Nội dung danh sách trắng hoặc danh sách đen
 - Bất kỳ thông tin nào có thể liên kết báo cáo với bạn

--- a/website/src/content/docs/vi/tab-groups.mdx
+++ b/website/src/content/docs/vi/tab-groups.mdx
@@ -47,11 +47,11 @@ Ngay cả khi giải phóng nhóm, bảo vệ tab riêng lẻ vẫn áp dụng:
 | Loại tab | Hành vi |
 |----------|---------|
 | **Tab ghim** | Được bảo vệ (nếu "Giải phóng tab ghim" bị tắt) |
-| **Tab audio** | Được bảo vệ (nếu "Bảo vệ tab audio" được bật) |
-| **Tab form** | Được bảo vệ (nếu "Bảo vệ tab form" được bật) |
+| **Tab âm thanh** | Được bảo vệ (nếu "Bảo vệ tab âm thanh" được bật) |
+| **Tab biểu mẫu** | Được bảo vệ (nếu "Bảo vệ tab biểu mẫu" được bật) |
 | **Danh sách trắng** | Được bảo vệ (luôn luôn) |
 
-**Ví dụ**: Nếu bạn giải phóng nhóm có 10 tab, nhưng 2 tab có form chưa lưu, chỉ 8 tab sẽ được giải phóng.
+**Ví dụ**: Nếu bạn giải phóng nhóm có 10 tab, nhưng 2 tab có biểu mẫu chưa lưu, chỉ 8 tab sẽ được giải phóng.
 
 ## Giải phóng tự động
 

--- a/website/src/content/docs/vi/troubleshooting.mdx
+++ b/website/src/content/docs/vi/troubleshooting.mdx
@@ -18,8 +18,8 @@ Giải pháp cho các vấn đề phổ biến khi sử dụng TabRest.
 TabRest bảo vệ một số tab theo mặc định. Kiểm tra xem tab có:
 
 - **Được ghim**: Tab ghim được bảo vệ (trừ khi "Giải phóng tab ghim" được bật)
-- **Đang phát audio**: Tab có audio đang hoạt động được bảo vệ (trừ khi "Bảo vệ tab audio" bị tắt)
-- **Có form chưa lưu**: Tab có trường input đã thay đổi được bảo vệ (trừ khi "Bảo vệ tab form" bị tắt)
+- **Đang phát âm thanh**: Tab có âm thanh đang hoạt động được bảo vệ (trừ khi "Bảo vệ tab âm thanh" bị tắt)
+- **Có biểu mẫu chưa lưu**: Tab có trường input đã thay đổi được bảo vệ (trừ khi "Bảo vệ tab biểu mẫu" bị tắt)
 - **Nằm trong danh sách trắng**: Domain nằm trong danh sách trắng của bạn
 
 **Giải pháp**: Tắt bảo vệ liên quan trong Cài đặt hoặc xóa domain khỏi danh sách trắng.
@@ -147,7 +147,7 @@ Một số phím tắt không hoạt động trên:
 2. Tìm tab đánh dấu "Đã giải phóng" hoặc có bộ nhớ rất thấp (< 1 MB)
 3. Nếu tab hiển thị bộ nhớ cao, chúng chưa được giải phóng
 
-**Giải pháp**: Kiểm tra cài đặt bảo vệ tab (ghim, audio, form, danh sách trắng).
+**Giải pháp**: Kiểm tra cài đặt bảo vệ tab (ghim, âm thanh, biểu mẫu, danh sách trắng).
 
 ### Kiểm tra cài đặt tự động giải phóng
 
@@ -241,7 +241,7 @@ Chrome có sẵn tính năng giải phóng tab (`chrome://settings/performance` 
 
 **Cách xác nhận đây là nguyên nhân**:
 
-1. Tab bị giải phóng mà không thấy toast cảnh báo của TabRest hiện trước
+1. Tab bị giải phóng mà không thấy thông báo cảnh báo của TabRest hiện trước
 2. Tab vẫn bị giải phóng ngay cả khi TabRest đang tạm dừng hoặc tắt
 3. Bạn thấy Memory Saver đang được bật tại `chrome://settings/performance`
 
@@ -250,20 +250,20 @@ Chrome có sẵn tính năng giải phóng tab (`chrome://settings/performance` 
 - **Cách A**: Mở `chrome://settings/performance` và tắt Memory Saver. TabRest sẽ có toàn quyền kiểm soát.
 - **Cách B**: Giữ Memory Saver bật, đồng thời thêm domain vào danh sách **Always keep these sites active** của Chrome tại `chrome://settings/performance`. Bạn sẽ phải tự đồng bộ giữa danh sách trắng của TabRest và danh sách của Chrome.
 
-Xem [Cấu hình danh sách trắng -> Cùng tồn tại với Chrome Memory Saver](/vi/docs/whitelist-config#cùng-tồn-tại-với-chrome-memory-saver) để biết giải thích đầy đủ.
+Xem [Cấu hình danh sách trắng -> Cùng tồn tại với Chrome Memory Saver](/vi/docs/whitelist-config#cung-ton-tai-voi-chrome-memory-saver) để biết giải thích đầy đủ.
 
-## Bảo vệ form không hoạt động
+## Bảo vệ biểu mẫu không hoạt động
 
-**Vấn đề**: Tab có form chưa lưu bị giải phóng.
+**Vấn đề**: Tab có biểu mẫu chưa lưu bị giải phóng.
 
-### Kiểm tra cài đặt bảo vệ form
+### Kiểm tra cài đặt bảo vệ biểu mẫu
 
 1. Mở Cài đặt
-2. Đảm bảo **Bảo vệ tab có form chưa lưu** được bật
+2. Đảm bảo **Bảo vệ tab có biểu mẫu chưa lưu** được bật
 
-### Xác minh phát hiện form
+### Xác minh phát hiện biểu mẫu
 
-TabRest phát hiện form với:
+TabRest phát hiện biểu mẫu với:
 - Trường `<input>` đã thay đổi (text, email, password, v.v.)
 - Trường `<textarea>` đã thay đổi
 - Dropdown `<select>` đã thay đổi
@@ -271,15 +271,15 @@ TabRest phát hiện form với:
 **KHÔNG phát hiện**:
 - Trình soạn thảo rich text (vd: TinyMCE, CKEditor) - dùng danh sách trắng thay thế
 - Trình soạn thảo dựa trên canvas
-- Thư viện form JavaScript tùy chỉnh
+- Thư viện biểu mẫu JavaScript tùy chỉnh
 
-**Giải pháp**: Thêm các trang có form phức tạp vào danh sách trắng.
+**Giải pháp**: Thêm các trang có biểu mẫu phức tạp vào danh sách trắng.
 
 ### Thời điểm content script
 
-Nếu form được điền rất nhanh sau khi trang tải, TabRest có thể chưa phát hiện được.
+Nếu biểu mẫu được điền rất nhanh sau khi trang tải, TabRest có thể chưa phát hiện được.
 
-**Giải pháp**: Đợi vài giây sau khi điền form trước khi chuyển tab.
+**Giải pháp**: Đợi vài giây sau khi điền biểu mẫu trước khi chuyển tab.
 
 ## Side Panel không mở
 
@@ -328,19 +328,19 @@ Cảnh báo chỉ xuất hiện khi tab **tự động** giải phóng (không g
 
 **Ghi chú**: Giải phóng thủ công không hiển thị cảnh báo.
 
-### Trang web chặn toast
+### Trang web chặn thông báo
 
-Một số trang web có thể chặn toast notification:
+Một số trang web có thể chặn thông báo trên trang:
 
 **Giải pháp**: Cảnh báo vẫn hoạt động nếu bạn nhìn thấy nó trên một số trang khác.
 
-## Form Protection xin quyền
+## Bảo vệ biểu mẫu xin quyền
 
-**Vấn đề**: TabRest yêu cầu quyền host (`http://*/*`, `https://*/*`) cho form protection.
+**Vấn đề**: TabRest yêu cầu quyền truy cập trang (`http://*/*`, `https://*/*`) cho bảo vệ biểu mẫu.
 
 ### Tại sao cần quyền này?
 
-Để phát hiện form chưa lưu, TabRest cần inject content script vào các trang web. Quyền này là **tùy chọn** - bạn có thể từ chối nó.
+Để phát hiện biểu mẫu chưa lưu, TabRest cần inject content script vào các trang web. Quyền này là **tùy chọn** - bạn có thể từ chối nó.
 
 ### Cấp quyền
 

--- a/website/src/content/docs/vi/whitelist-config.mdx
+++ b/website/src/content/docs/vi/whitelist-config.mdx
@@ -129,13 +129,13 @@ Danh sách trắng hoạt động cùng các bảo vệ tab khác:
 |-------------|---------|-------|
 | Danh sách trắng | Cao nhất | Bảo vệ dựa trên domain |
 | Tab ghim | Cao | Bảo vệ tab ghim (có thể cấu hình) |
-| Tab audio | Cao | Bảo vệ tab đang phát media (có thể cấu hình) |
-| Tab form | Cao | Bảo vệ tab có form chưa lưu (có thể cấu hình) |
+| Tab âm thanh | Cao | Bảo vệ tab đang phát media (có thể cấu hình) |
+| Tab biểu mẫu | Cao | Bảo vệ tab có biểu mẫu chưa lưu (có thể cấu hình) |
 
 **Ví dụ**: Ngay cả khi trang không nằm trong danh sách trắng, nó vẫn không bị giải phóng nếu:
 - Tab được ghim (và "Giải phóng tab ghim" bị tắt)
-- Tab đang phát audio (và "Bảo vệ tab audio" được bật)
-- Tab có dữ liệu form chưa lưu (và "Bảo vệ tab form" được bật)
+- Tab đang phát âm thanh (và "Bảo vệ tab âm thanh" được bật)
+- Tab có dữ liệu biểu mẫu chưa lưu (và "Bảo vệ tab biểu mẫu" được bật)
 
 ## Import/Export danh sách + Sessions
 

--- a/website/src/i18n/translations.ts
+++ b/website/src/i18n/translations.ts
@@ -276,7 +276,7 @@ export const translations = {
         {
           icon: 'shield',
           title: 'Danh sách trắng thông minh',
-          description: 'Bảo vệ các tab quan trọng với danh sách domain và quy tắc đặc biệt cho audio/form',
+          description: 'Bảo vệ các tab quan trọng với danh sách domain và quy tắc đặc biệt cho âm thanh/biểu mẫu',
         },
         {
           icon: 'keyboard',
@@ -310,7 +310,7 @@ export const translations = {
         },
         {
           icon: 'battery',
-          title: 'Chế độ nguồn',
+          title: 'Chế độ tiết kiệm',
           description: 'Chuyển đổi giữa Tiết kiệm pin, Bình thường và Hiệu suất để điều chỉnh mức độ tích cực',
         },
         {
@@ -378,7 +378,7 @@ export const translations = {
         },
         {
           question: 'Tôi có thể ngăn một số tab bị giải phóng không?',
-          answer: 'Có! Thêm domain vào danh sách trắng trong cài đặt. Bạn cũng có thể bật bảo vệ tự động cho tab đang phát audio hoặc có form chưa lưu.',
+          answer: 'Có! Thêm domain vào danh sách trắng trong cài đặt. Bạn cũng có thể bật bảo vệ tự động cho tab đang phát âm thanh hoặc có biểu mẫu chưa lưu.',
         },
         {
           question: 'TabRest có hoạt động offline không?',


### PR DESCRIPTION
## Summary

Native-quality polish pass on Vietnamese translations across 14 files (extension UI, README, docs, website MDX). Glossary-driven; 159 prose edits + 4 anchor bug fixes.

- **Phase 02** - Extension UI strings: 38 edits in `_locales/vi/messages.json` + `translations.ts`. Replaces 'Dỡ' -> 'Giải phóng' (28 keys), 'được bảo vệ' -> 'đã bảo vệ', suspend warning + side panel/popup terminology, audio/form leaks, power-mode naming.
- **Phase 03** - README + listings + docs/vi standalones: ~85 edits across `README.vi.md`, `chrome-web-store-listing.md`, `feature-test-checklist.md`, `unload-decision-matrix.md`. Removes machine-translation tells (English nouns mid-VN-prose).
- **Phase 04** - Website MDX docs: ~30 edits across 7 of 8 VI MDX files; 1 file (keyboard-shortcuts.mdx) needed no changes.
- **Phase 06 cleanup** - 4 leftover Phase 04 misses + 4 pre-existing broken anchor links fixed (Vietnamese diacritics in URL anchors that don't match Astro's slugified output).

Decisions captured in plan reports: snooze kept as 'tạm hoãn' (production wording, more natural for postpone), powerMode aligned to 'Chế độ tiết kiệm' (per glossary).

Non-VI 9 locales were audited - already glossary-compliant, no edits needed.

## Test plan

- [x] `pnpm --filter website build` passes (20 pages, 0 warnings)
- [x] All 10 `_locales/*/messages.json` parse + 220/220 key parity vs en
- [x] Zero Chrome i18n placeholder count mismatches
- [x] All in-repo `/vi/docs/...#anchor` links resolve to existing headings
- [x] `getMemorySaverDocsUrl()` hardcoded slug `cung-ton-tai-voi-chrome-memory-saver` matches preserved heading at `whitelist-config.mdx:252`
- [x] Zero leftover 'Dỡ'/'dỡ' in any VI surface
- [ ] Manual: load unpacked extension in Chrome with vi locale, verify popup/options/onboarding/context menu read naturally