### PR TITLE
chore(docs): refresh GitNexus index counts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **tabrest** (2176 symbols, 3410 relationships, 104 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **tabrest** (2590 symbols, 3976 relationships, 106 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,10 +78,9 @@ content/
 - **Exception**: UI placeholder values that intentionally render `—` as a "no value" indicator (e.g., `src/popup/popup.html` stat cells, `src/popup/popup.js` `textContent = "—"`). Do not change those.
 
 <!-- gitnexus:start -->
-
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **tabrest** (2176 symbols, 3410 relationships, 104 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **tabrest** (2590 symbols, 3976 relationships, 106 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
@@ -102,22 +101,22 @@ This project is indexed by GitNexus as **tabrest** (2176 symbols, 3410 relations
 
 ## Resources
 
-| Resource                                 | Use for                                  |
-| ---------------------------------------- | ---------------------------------------- |
-| `gitnexus://repo/tabrest/context`        | Codebase overview, check index freshness |
-| `gitnexus://repo/tabrest/clusters`       | All functional areas                     |
-| `gitnexus://repo/tabrest/processes`      | All execution flows                      |
-| `gitnexus://repo/tabrest/process/{name}` | Step-by-step execution trace             |
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/tabrest/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/tabrest/clusters` | All functional areas |
+| `gitnexus://repo/tabrest/processes` | All execution flows |
+| `gitnexus://repo/tabrest/process/{name}` | Step-by-step execution trace |
 
 ## CLI
 
-| Task                                         | Read this skill file                                        |
-| -------------------------------------------- | ----------------------------------------------------------- |
-| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md`       |
-| Blast radius / "What breaks if I change X?"  | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
-| Trace bugs / "Why is X failing?"             | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md`       |
-| Rename / extract / split / refactor          | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md`     |
-| Tools, resources, schema reference           | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md`           |
-| Index, status, clean, wiki CLI commands      | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md`             |
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
 
 <!-- gitnexus:end -->


### PR DESCRIPTION
## Summary
- Update GitNexus symbol/relationship/flow counts in `AGENTS.md` and `CLAUDE.md` to match the latest index (2590 symbols, 3976 relationships, 106 flows)
- Reformat GitNexus tables in `CLAUDE.md` for compact rendering

## Test plan
- [x] Docs only - no code changes
- [x] Verify markdown renders correctly on GitHub