### PR TITLE
chore(config): tune default whitelist and RAM threshold

### DIFF
--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -2,8 +2,8 @@
 export const SETTINGS_DEFAULTS = {
   autoUnloadOnStartup: true,
   unloadDelayMinutes: 30,
-  memoryThresholdPercent: 80,
-  whitelist: ["youtube.com", "gmail.com", "docs.google.com", "miro.com", "figma.com", "notion.so"],
+  memoryThresholdPercent: 90,
+  whitelist: ["youtube.com", "meet.google.com"],
   blacklist: [],
   unloadPinnedTabs: false,
   protectAudioTabs: true,
@@ -56,9 +56,11 @@ export const YOUTUBE_TIMESTAMP_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 export const WHITELIST_SUGGESTIONS = Object.freeze([
   "gmail.com",
   "docs.google.com",
+  "meet.google.com",
   "github.com",
   "notion.so",
   "figma.com",
+  "miro.com",
   "youtube.com",
 ]);
 


### PR DESCRIPTION
## Summary
- Raise default RAM threshold from 80% to 90% for less aggressive tab unloading
- Trim default whitelist to `youtube.com` and `meet.google.com` only (sites with active media/calls)
- Move productivity sites (`gmail.com`, `docs.google.com`, `figma.com`, `notion.so`, `miro.com`) to onboarding suggestion list so users opt-in during setup

## Test plan
- [x] Fresh install: verify only youtube.com and meet.google.com in whitelist
- [x] Fresh install: verify RAM threshold defaults to 90%
- [x] Onboarding wizard step 3: verify all suggestion sites appear (gmail, docs, meet, github, notion, figma, miro, youtube)
- [x] Existing install: verify saved settings are not overwritten