### PR TITLE
feat(popup): add site whitelist toggle bar

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -182,6 +182,24 @@
   "whitelistHelp": {
     "message": "Sites, die nie automatisch entladen werden"
   },
+  "neverUnloadSite": {
+    "message": "Nie entladen"
+  },
+  "whitelistedClickRemove": {
+    "message": "Geschützt"
+  },
+  "whitelistedStatus": {
+    "message": "Geschützt - wird nicht entladen"
+  },
+  "activeStatus": {
+    "message": "Aktiv"
+  },
+  "siteWhitelisted": {
+    "message": "Site zur Whitelist hinzugefügt"
+  },
+  "siteRemovedFromWhitelist": {
+    "message": "Site von der Whitelist entfernt"
+  },
   "memorySaverNoteBody": {
     "message": "Chromes integrierter Speichersparmodus läuft separat und kann diese Sites trotzdem entladen."
   },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -241,6 +241,30 @@
     "message": "Sites that will never be unloaded automatically",
     "description": "Options help text"
   },
+  "neverUnloadSite": {
+    "message": "Never unload",
+    "description": "Popup whitelist bar button label when site is not whitelisted"
+  },
+  "whitelistedClickRemove": {
+    "message": "Whitelisted",
+    "description": "Popup whitelist bar button label when site is whitelisted"
+  },
+  "whitelistedStatus": {
+    "message": "Whitelisted - won't be unloaded",
+    "description": "Popup whitelist bar status text when site is whitelisted"
+  },
+  "activeStatus": {
+    "message": "Active",
+    "description": "Popup whitelist bar status text when site is not whitelisted"
+  },
+  "siteWhitelisted": {
+    "message": "Site whitelisted",
+    "description": "Toast when site added to whitelist from popup"
+  },
+  "siteRemovedFromWhitelist": {
+    "message": "Site removed from whitelist",
+    "description": "Toast when site removed from whitelist from popup"
+  },
   "memorySaverNoteBody": {
     "message": "Chrome's built-in Memory Saver runs separately and may still unload these sites.",
     "description": "Info note body shown next to whitelist surfaces (onboarding step and options page) explaining that Chrome's Memory Saver is independent of TabRest."

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -182,6 +182,24 @@
   "whitelistHelp": {
     "message": "Sitios que nunca se descargarán automáticamente"
   },
+  "neverUnloadSite": {
+    "message": "No descargar"
+  },
+  "whitelistedClickRemove": {
+    "message": "Protegido"
+  },
+  "whitelistedStatus": {
+    "message": "Protegido - no se descargará"
+  },
+  "activeStatus": {
+    "message": "Activo"
+  },
+  "siteWhitelisted": {
+    "message": "Sitio añadido a la lista blanca"
+  },
+  "siteRemovedFromWhitelist": {
+    "message": "Sitio eliminado de la lista blanca"
+  },
   "memorySaverNoteBody": {
     "message": "El Ahorro de memoria integrado de Chrome funciona por separado y aún puede descargar estos sitios."
   },

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -182,6 +182,24 @@
   "whitelistHelp": {
     "message": "Sites qui ne seront jamais déchargés automatiquement"
   },
+  "neverUnloadSite": {
+    "message": "Ne pas décharger"
+  },
+  "whitelistedClickRemove": {
+    "message": "Protégé"
+  },
+  "whitelistedStatus": {
+    "message": "Protégé - ne sera pas déchargé"
+  },
+  "activeStatus": {
+    "message": "Actif"
+  },
+  "siteWhitelisted": {
+    "message": "Site ajouté à la liste blanche"
+  },
+  "siteRemovedFromWhitelist": {
+    "message": "Site retiré de la liste blanche"
+  },
   "memorySaverNoteBody": {
     "message": "L'économiseur de mémoire intégré de Chrome fonctionne séparément et peut tout de même décharger ces sites."
   },

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -182,6 +182,24 @@
   "whitelistHelp": {
     "message": "Situs yang tidak akan pernah dibongkar secara otomatis"
   },
+  "neverUnloadSite": {
+    "message": "Jangan bongkar"
+  },
+  "whitelistedClickRemove": {
+    "message": "Dilindungi"
+  },
+  "whitelistedStatus": {
+    "message": "Dilindungi - tidak akan dibongkar"
+  },
+  "activeStatus": {
+    "message": "Aktif"
+  },
+  "siteWhitelisted": {
+    "message": "Situs ditambahkan ke daftar putih"
+  },
+  "siteRemovedFromWhitelist": {
+    "message": "Situs dihapus dari daftar putih"
+  },
   "memorySaverNoteBody": {
     "message": "Penghemat Memori bawaan Chrome berjalan terpisah dan masih dapat membongkar situs ini."
   },

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -182,6 +182,24 @@
   "whitelistHelp": {
     "message": "自動アンロードの対象にならないサイト"
   },
+  "neverUnloadSite": {
+    "message": "アンロードしない"
+  },
+  "whitelistedClickRemove": {
+    "message": "ホワイトリスト済み"
+  },
+  "whitelistedStatus": {
+    "message": "ホワイトリスト済み - アンロードされません"
+  },
+  "activeStatus": {
+    "message": "アクティブ"
+  },
+  "siteWhitelisted": {
+    "message": "サイトをホワイトリストに追加しました"
+  },
+  "siteRemovedFromWhitelist": {
+    "message": "サイトをホワイトリストから削除しました"
+  },
   "memorySaverNoteBody": {
     "message": "Chrome の組み込みメモリ セーバーは独立して動作し、これらのサイトをアンロードすることがあります。"
   },

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -182,6 +182,24 @@
   "whitelistHelp": {
     "message": "자동으로 언로드되지 않는 사이트"
   },
+  "neverUnloadSite": {
+    "message": "언로드 안 함"
+  },
+  "whitelistedClickRemove": {
+    "message": "허용됨"
+  },
+  "whitelistedStatus": {
+    "message": "허용됨 - 언로드되지 않음"
+  },
+  "activeStatus": {
+    "message": "활성"
+  },
+  "siteWhitelisted": {
+    "message": "사이트가 허용 목록에 추가됨"
+  },
+  "siteRemovedFromWhitelist": {
+    "message": "사이트가 허용 목록에서 제거됨"
+  },
   "memorySaverNoteBody": {
     "message": "Chrome 내장 메모리 절약 모드는 별도로 실행되며 이러한 사이트를 언로드할 수 있습니다."
   },

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -182,6 +182,24 @@
   "whitelistHelp": {
     "message": "Sites que nunca serão descarregados automaticamente"
   },
+  "neverUnloadSite": {
+    "message": "Não descarregar"
+  },
+  "whitelistedClickRemove": {
+    "message": "Protegido"
+  },
+  "whitelistedStatus": {
+    "message": "Protegido - não será descarregado"
+  },
+  "activeStatus": {
+    "message": "Ativo"
+  },
+  "siteWhitelisted": {
+    "message": "Site adicionado à lista branca"
+  },
+  "siteRemovedFromWhitelist": {
+    "message": "Site removido da lista branca"
+  },
   "memorySaverNoteBody": {
     "message": "O Economizador de memória integrado do Chrome é executado separadamente e ainda pode descarregar esses sites."
   },

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -182,6 +182,24 @@
   "whitelistHelp": {
     "message": "Сайты, которые никогда не выгружаются автоматически"
   },
+  "neverUnloadSite": {
+    "message": "Не выгружать"
+  },
+  "whitelistedClickRemove": {
+    "message": "В белом списке"
+  },
+  "whitelistedStatus": {
+    "message": "В белом списке - не будет выгружен"
+  },
+  "activeStatus": {
+    "message": "Активен"
+  },
+  "siteWhitelisted": {
+    "message": "Сайт добавлен в белый список"
+  },
+  "siteRemovedFromWhitelist": {
+    "message": "Сайт удалён из белого списка"
+  },
   "memorySaverNoteBody": {
     "message": "Встроенная экономия памяти Chrome работает отдельно и может выгружать эти сайты."
   },

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -178,6 +178,24 @@
   "whitelistHelp": {
     "message": "Các trang sẽ không bao giờ bị dỡ tự động"
   },
+  "neverUnloadSite": {
+    "message": "Không dỡ"
+  },
+  "whitelistedClickRemove": {
+    "message": "Đã bảo vệ"
+  },
+  "whitelistedStatus": {
+    "message": "Đã bảo vệ - sẽ không bị dỡ"
+  },
+  "activeStatus": {
+    "message": "Đang hoạt động"
+  },
+  "siteWhitelisted": {
+    "message": "Đã thêm vào danh sách trắng"
+  },
+  "siteRemovedFromWhitelist": {
+    "message": "Đã xóa khỏi danh sách trắng"
+  },
   "memorySaverNoteBody": {
     "message": "Tính năng Memory Saver tích hợp của Chrome chạy độc lập và vẫn có thể dỡ các trang này."
   },

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -182,6 +182,24 @@
   "whitelistHelp": {
     "message": "这些网站不会被自动释放"
   },
+  "neverUnloadSite": {
+    "message": "不释放"
+  },
+  "whitelistedClickRemove": {
+    "message": "已加白名单"
+  },
+  "whitelistedStatus": {
+    "message": "已加白名单 - 不会被释放"
+  },
+  "activeStatus": {
+    "message": "活跃"
+  },
+  "siteWhitelisted": {
+    "message": "网站已加入白名单"
+  },
+  "siteRemovedFromWhitelist": {
+    "message": "网站已从白名单移除"
+  },
   "memorySaverNoteBody": {
     "message": "Chrome 内置的内存节省程序独立运行，仍可能释放这些网站。"
   },

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -36,7 +36,7 @@ tabrest/
 
 | File                 | LOC | Purpose                                                                                                           |
 | -------------------- | --- | ----------------------------------------------------------------------------------------------------------------- |
-| `service-worker.js`  | 618 | Orchestrator: events, alarms, message routing; error capture handler for `captureError`/`captureMessage` commands |
+| `service-worker.js`  | 702 | Orchestrator: events, alarms, message routing; error capture handler for `captureError`/`captureMessage` commands |
 | `unload-manager.js`  | 348 | Core discard logic, protection checks, batch ops                                                                  |
 | `tab-tracker.js`     | 172 | LRU activity tracking, inactivity timer checks                                                                    |
 | `memory-monitor.js`  | 196 | System RAM monitoring, per-tab JS heap tracking                                                                   |
@@ -56,9 +56,9 @@ tabrest/
 
 | File                   | LOC  | Purpose                                                                               |
 | ---------------------- | ---- | ------------------------------------------------------------------------------------- |
-| `popup/popup.js`       | 974  | Main popup logic, tab list, actions, "Send to Sentry" button in bug report modal      |
-| `popup/popup.html`     | 238  | Popup markup (reused for side panel)                                                  |
-| `popup/popup.css`      | 1053 | Popup styles                                                                          |
+| `popup/popup.js`       | 1168 | Main popup logic, tab list, actions, site whitelist toggle, bug report modal           |
+| `popup/popup.html`     | 314  | Popup markup (reused for side panel)                                                  |
+| `popup/popup.css`      | 1432 | Popup styles                                                                          |
 | `options/options.js`   | 428  | Settings management, Privacy & Diagnostics section with error reporting toggle        |
 | `options/options.html` | 267  | Options page markup, new Privacy & Diagnostics section with toggle + custom DSN field |
 | `options/options.css`  | 401  | Options styles                                                                        |

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -184,6 +184,36 @@ service-worker.js
 7. popup.js: Refresh tab list
 ```
 
+### Toggle Whitelist from Popup
+
+```text
+1. Popup opens: renderSiteWhitelistBar()
+       │
+       ├── Query active tab hostname
+       ├── Check settings.whitelist for match
+       │
+       ▼
+2. Show bar with domain, favicon, toggle button
+       │
+       ▼
+3. User clicks toggle button
+       │
+       ▼
+4. popup.js: sendCommand("toggle-whitelist", { hostname })
+       │
+       ▼
+5. service-worker.js: handleMessage()
+       │
+       ├── Add hostname if not in whitelist
+       ├── Remove hostname if already in whitelist
+       │
+       ▼
+6. saveSettings() + return { whitelisted: boolean }
+       │
+       ▼
+7. popup.js: Update button state + refresh tab list
+```
+
 ## Storage Architecture
 
 ### chrome.storage.sync (Cross-device)
@@ -382,6 +412,7 @@ service-worker.js
 { command: "save-session", name: "Research" }
 { command: "restore-session", id: "abc123", mode: "replace" }
 { command: "import-sessions", data: [...] }  // Import with merge & dedup
+{ command: "toggle-whitelist", hostname: "example.com" }
 ```
 
 ### Content Script → Background

--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -528,7 +528,8 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
 // Handle messages from popup
 async function handleMessage(message) {
-  const { command, groupId, tabId, name, id, mode, minutes, domain, url, sessions } = message;
+  const { command, groupId, tabId, name, id, mode, minutes, domain, url, sessions, hostname } =
+    message;
 
   switch (command) {
     case "unload-current":
@@ -582,6 +583,19 @@ async function handleMessage(message) {
       return await getTabSnoozeInfo(tabId, url);
     case "get-active-snoozes":
       return await getActiveSnoozes();
+    case "toggle-whitelist": {
+      const normalized = unwrapHostname(hostname ?? "").replace(/^www\./, "");
+      if (!normalized || !isValidDomainOrIp(normalized)) return { whitelisted: false };
+      const s = await getSettings();
+      const idx = s.whitelist.indexOf(normalized);
+      if (idx >= 0) {
+        s.whitelist.splice(idx, 1);
+      } else {
+        s.whitelist.push(normalized);
+      }
+      await saveSettings(s);
+      return { whitelisted: idx < 0 };
+    }
     default:
       return null;
   }

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -750,6 +750,94 @@ footer {
   border-top: 1px solid var(--border);
 }
 
+/* Site Whitelist Bar */
+.site-whitelist-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  margin-bottom: 8px;
+}
+
+.site-whitelist-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+}
+
+.site-whitelist-favicon {
+  width: 16px;
+  height: 16px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.site-whitelist-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.site-whitelist-domain {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.site-whitelist-status {
+  font-size: 10px;
+  color: var(--text-muted);
+}
+
+.site-whitelist-btn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 10px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--background);
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.site-whitelist-btn:hover {
+  border-color: var(--secondary);
+  color: var(--text);
+}
+
+.site-whitelist-btn.active {
+  background: rgba(5, 150, 105, 0.1);
+  border-color: var(--success);
+  color: var(--success);
+}
+
+[data-theme="dark"] .site-whitelist-btn.active {
+  background: rgba(110, 231, 183, 0.12);
+  color: var(--success);
+  border-color: var(--success);
+}
+
+.site-whitelist-btn.active:hover {
+  background: rgba(5, 150, 105, 0.18);
+}
+
+[data-theme="dark"] .site-whitelist-btn.active:hover {
+  background: rgba(110, 231, 183, 0.2);
+}
+
 /* Quick Actions Row */
 .quick-actions {
   display: flex;

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -73,6 +73,21 @@
       </div>
     </div>
 
+    <!-- Current Site Whitelist Toggle -->
+    <div class="site-whitelist-bar" id="site-whitelist-bar" style="display: none;">
+      <div class="site-whitelist-info">
+        <img class="site-whitelist-favicon" id="site-whitelist-favicon" src="" alt="">
+        <div class="site-whitelist-text">
+          <span class="site-whitelist-domain" id="site-whitelist-domain"></span>
+          <span class="site-whitelist-status" id="site-whitelist-status"></span>
+        </div>
+      </div>
+      <button class="site-whitelist-btn" id="site-whitelist-btn">
+        <span id="site-whitelist-icon"></span>
+        <span id="site-whitelist-label"></span>
+      </button>
+    </div>
+
     <!-- Quick Actions -->
     <div class="quick-actions">
       <button class="btn btn-primary" id="unload-others">

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -68,6 +68,14 @@ const elements = {
   reviewYes: document.getElementById("review-yes"),
   reviewNo: document.getElementById("review-no"),
   reviewDismiss: document.getElementById("review-dismiss"),
+  // Site whitelist bar
+  siteWhitelistBar: document.getElementById("site-whitelist-bar"),
+  siteWhitelistFavicon: document.getElementById("site-whitelist-favicon"),
+  siteWhitelistDomain: document.getElementById("site-whitelist-domain"),
+  siteWhitelistStatus: document.getElementById("site-whitelist-status"),
+  siteWhitelistBtn: document.getElementById("site-whitelist-btn"),
+  siteWhitelistIcon: document.getElementById("site-whitelist-icon"),
+  siteWhitelistLabel: document.getElementById("site-whitelist-label"),
   // Form permission recovery banner
   formPermBanner: document.getElementById("form-perm-banner"),
   formPermGrant: document.getElementById("form-perm-grant"),
@@ -299,6 +307,54 @@ async function updateStats() {
       elements.ramStat.title = `System RAM usage: ${usagePercent}%`;
     }
   }
+}
+
+// --- Site Whitelist Bar ---
+
+let currentSiteHostname = "";
+
+async function renderSiteWhitelistBar() {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (!tab?.url || !isSafeHttpUrl(tab.url)) {
+    elements.siteWhitelistBar.style.display = "none";
+    return;
+  }
+
+  const hostname = getHostname(tab.url);
+  if (!hostname) {
+    elements.siteWhitelistBar.style.display = "none";
+    return;
+  }
+
+  currentSiteHostname = hostname;
+  const settings = await getSettings();
+  const isWhitelisted = settings.whitelist.includes(hostname);
+
+  elements.siteWhitelistDomain.textContent = hostname;
+  if (tab.favIconUrl && isSafeHttpUrl(tab.favIconUrl)) {
+    elements.siteWhitelistFavicon.src = tab.favIconUrl;
+    elements.siteWhitelistFavicon.style.display = "";
+    attachFaviconErrorHandlers(elements.siteWhitelistBar, ".site-whitelist-favicon");
+  } else {
+    elements.siteWhitelistFavicon.style.display = "none";
+  }
+
+  updateWhitelistBtnState(isWhitelisted);
+  elements.siteWhitelistBar.style.display = "";
+  injectIcons();
+}
+
+function updateWhitelistBtnState(isWhitelisted) {
+  elements.siteWhitelistIcon.innerHTML = isWhitelisted
+    ? icon("shieldCheck", 14)
+    : icon("shield", 14);
+  elements.siteWhitelistLabel.textContent = isWhitelisted
+    ? t("whitelistedClickRemove") || "Whitelisted"
+    : t("neverUnloadSite") || "Never unload";
+  elements.siteWhitelistStatus.textContent = isWhitelisted
+    ? t("whitelistedStatus") || "Whitelisted - won't be unloaded"
+    : t("activeStatus") || "Active";
+  elements.siteWhitelistBtn.classList.toggle("active", isWhitelisted);
 }
 
 let lastTabGroupsKey = "";
@@ -942,6 +998,19 @@ function setupEventListeners() {
     hideReviewPrompt();
   });
 
+  // Site whitelist toggle
+  elements.siteWhitelistBtn?.addEventListener("click", async () => {
+    if (!currentSiteHostname) return;
+    const result = await sendCommand("toggle-whitelist", { hostname: currentSiteHostname });
+    updateWhitelistBtnState(result.whitelisted);
+    showToast(
+      result.whitelisted
+        ? t("siteWhitelisted") || "Site whitelisted"
+        : t("siteRemovedFromWhitelist") || "Site removed from whitelist",
+    );
+    await renderTabList();
+  });
+
   // Form permission recovery banner handlers
   elements.formPermGrant?.addEventListener("click", handleFormPermGrant);
   elements.formPermDismiss?.addEventListener("click", dismissFormPermBanner);
@@ -1046,6 +1115,7 @@ async function init() {
     renderTabList(),
     renderSessions(),
     renderDetailedStats(),
+    renderSiteWhitelistBar(),
     checkReviewPrompt(),
     checkFormPermBanner(),
   ]);
@@ -1075,7 +1145,9 @@ function setupTabEventSync() {
   tabEventSyncBound = true;
 
   const scheduleRefresh = leadingDebounce(renderTabList);
+  const scheduleWhitelistRefresh = leadingDebounce(renderSiteWhitelistBar);
   chrome.tabs.onActivated.addListener(scheduleRefresh);
+  chrome.tabs.onActivated.addListener(scheduleWhitelistRefresh);
   chrome.tabs.onUpdated.addListener((_id, changeInfo) => {
     if ("discarded" in changeInfo || "title" in changeInfo || "favIconUrl" in changeInfo) {
       scheduleRefresh();

--- a/website/package.json
+++ b/website/package.json
@@ -10,8 +10,8 @@
   "dependencies": {
     "@astrojs/mdx": "5.0.4",
     "@astrojs/sitemap": "3.7.2",
-    "astro": "6.2.1",
-    "marked": "^18.0.0"
+    "astro": "6.2.2",
+    "marked": "18.0.3"
   },
   "devDependencies": {
     "@tailwindcss/typography": "0.5.19",

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -10,15 +10,15 @@ importers:
     dependencies:
       '@astrojs/mdx':
         specifier: 5.0.4
-        version: 5.0.4(astro@6.2.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(yaml@2.8.3))
+        version: 5.0.4(astro@6.2.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(yaml@2.8.3))
       '@astrojs/sitemap':
         specifier: 3.7.2
         version: 3.7.2
       astro:
-        specifier: 6.2.1
-        version: 6.2.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(yaml@2.8.3)
+        specifier: 6.2.2
+        version: 6.2.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(yaml@2.8.3)
       marked:
-        specifier: ^18.0.0
+        specifier: 18.0.3
         version: 18.0.3
     devDependencies:
       '@tailwindcss/typography':
@@ -767,8 +767,8 @@ packages:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
 
-  astro@6.2.1:
-    resolution: {integrity: sha512-3g1sYNly+QAkuO5ErNEQBYvsxorNDSCUNIeStBs+kcXGchvKQl1Q9EuDNOvSg010XLlHJFLVFZs9LV18Jjp4Hg==}
+  astro@6.2.2:
+    resolution: {integrity: sha512-zkne2lZU+iTZPBK8F4gbMfrw5f11bT4VXiBxcdFHcPvYyH+Hox7V1sZu97RDpvwmHi+wQ0efKv89KY5744a0jQ==}
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
 
@@ -1007,6 +1007,10 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  get-tsconfig@5.0.0-beta.4:
+    resolution: {integrity: sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==}
+    engines: {node: '>=20.20.0'}
+
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
@@ -1109,6 +1113,9 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -1535,6 +1542,9 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   retext-latin@4.0.0:
     resolution: {integrity: sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==}
 
@@ -1636,16 +1646,6 @@ packages:
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
-
-  tsconfck@3.1.6:
-    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
-    engines: {node: ^18 || >=20}
-    hasBin: true
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -1883,12 +1883,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@5.0.4(astro@6.2.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(yaml@2.8.3))':
+  '@astrojs/mdx@5.0.4(astro@6.2.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(yaml@2.8.3))':
     dependencies:
       '@astrojs/markdown-remark': 7.1.1
       '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 6.2.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(yaml@2.8.3)
+      astro: 6.2.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(yaml@2.8.3)
       es-module-lexer: 2.0.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -2438,7 +2438,7 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro@6.2.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(yaml@2.8.3):
+  astro@6.2.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(yaml@2.8.3):
     dependencies:
       '@astrojs/compiler': 4.0.0
       '@astrojs/internal-helpers': 0.9.0
@@ -2461,10 +2461,12 @@ snapshots:
       esbuild: 0.27.7
       flattie: 1.1.1
       fontace: 0.4.1
+      get-tsconfig: 5.0.0-beta.4
       github-slugger: 2.0.0
       html-escaper: 3.0.3
       http-cache-semantics: 4.2.0
       js-yaml: 4.1.1
+      jsonc-parser: 3.3.1
       magic-string: 0.30.21
       magicast: 0.5.2
       mrmime: 2.0.1
@@ -2483,7 +2485,6 @@ snapshots:
       tinyclip: 0.1.12
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
-      tsconfck: 3.1.6
       ultrahtml: 1.6.0
       unifont: 0.7.4
       unist-util-visit: 5.1.0
@@ -2527,7 +2528,6 @@ snapshots:
       - supports-color
       - terser
       - tsx
-      - typescript
       - uploadthing
       - yaml
 
@@ -2765,6 +2765,10 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  get-tsconfig@5.0.0-beta.4:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   github-slugger@2.0.0: {}
 
   graceful-fs@4.2.11: {}
@@ -2949,6 +2953,8 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsonc-parser@3.3.1: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -3679,6 +3685,8 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
+  resolve-pkg-maps@1.0.0: {}
+
   retext-latin@4.0.0:
     dependencies:
       '@types/nlcst': 2.0.3
@@ -3842,8 +3850,6 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
-
-  tsconfck@3.1.6: {}
 
   tslib@2.8.1:
     optional: true


### PR DESCRIPTION
## Summary
- Add a whitelist toggle bar to the popup showing the current tab's domain with a one-click button to add/remove from whitelist (inspired by Drowzy's "Never suspend this site" UX)
- Add `toggle-whitelist` command to service worker with proper hostname normalization and validation
- Support side-panel mode by refreshing the bar on tab switches
- Add i18n translations for all 11 supported locales
- Update system architecture and codebase summary docs

## Test plan
- [x] Open popup on an HTTP site - verify bar shows domain, favicon, and "Never unload" button
- [x] Click "Never unload" - verify button turns green "Whitelisted", toast appears, tab list updates with shield badge
- [x] Click "Whitelisted" again - verify it toggles back to "Never unload", toast shows removal message
- [x] Open popup on chrome:// or extension page - verify bar is hidden
- [x] Open side panel, switch tabs - verify bar updates to the new active tab's domain
- [x] Verify whitelist persists in Settings page after toggling from popup
- [x] Test with different locales (chrome://settings/languages) to verify translations