### PR TITLE
feat(settings): add reset to defaults button

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -116,6 +116,24 @@
   "thresholdUpdated": {
     "message": "Schwelle aktualisiert"
   },
+  "resetDefaults": {
+    "message": "Auf Standard zurücksetzen"
+  },
+  "confirmResetDefaults": {
+    "message": "Alle Einstellungen auf Standard zurücksetzen? Dies kann nicht rückgängig gemacht werden."
+  },
+  "settingsReset": {
+    "message": "Einstellungen auf Standard zurückgesetzt"
+  },
+  "confirmResetShort": {
+    "message": "Sind Sie sicher?"
+  },
+  "cancel": {
+    "message": "Abbrechen"
+  },
+  "confirmYes": {
+    "message": "Ja"
+  },
   "cannotUnloadActive": {
     "message": "Aktiver Tab kann nicht entladen werden"
   },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -153,6 +153,30 @@
     "message": "Threshold updated",
     "description": "Toast message"
   },
+  "resetDefaults": {
+    "message": "Reset to Defaults",
+    "description": "Button label to reset all settings to default values"
+  },
+  "confirmResetDefaults": {
+    "message": "Reset all settings to defaults? This cannot be undone.",
+    "description": "Confirmation dialog before resetting settings"
+  },
+  "settingsReset": {
+    "message": "Settings reset to defaults",
+    "description": "Toast message after resetting settings"
+  },
+  "confirmResetShort": {
+    "message": "Are you sure?",
+    "description": "Inline confirm text before resetting settings"
+  },
+  "cancel": {
+    "message": "Cancel",
+    "description": "Cancel button label"
+  },
+  "confirmYes": {
+    "message": "Yes",
+    "description": "Confirm button label for destructive actions"
+  },
   "cannotUnloadActive": {
     "message": "Cannot unload active tab",
     "description": "Toast message when trying to unload the current active tab"

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -116,6 +116,24 @@
   "thresholdUpdated": {
     "message": "Umbral actualizado"
   },
+  "resetDefaults": {
+    "message": "Restablecer valores predeterminados"
+  },
+  "confirmResetDefaults": {
+    "message": "Restablecer toda la configuración? Esto no se puede deshacer."
+  },
+  "settingsReset": {
+    "message": "Configuración restablecida"
+  },
+  "confirmResetShort": {
+    "message": "Estás seguro?"
+  },
+  "cancel": {
+    "message": "Cancelar"
+  },
+  "confirmYes": {
+    "message": "Sí"
+  },
   "cannotUnloadActive": {
     "message": "No se puede descargar la pestaña activa"
   },

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -116,6 +116,24 @@
   "thresholdUpdated": {
     "message": "Seuil mis à jour"
   },
+  "resetDefaults": {
+    "message": "Réinitialiser par défaut"
+  },
+  "confirmResetDefaults": {
+    "message": "Réinitialiser tous les paramètres par défaut ? Cette action est irréversible."
+  },
+  "settingsReset": {
+    "message": "Paramètres réinitialisés par défaut"
+  },
+  "confirmResetShort": {
+    "message": "Êtes-vous sûr ?"
+  },
+  "cancel": {
+    "message": "Annuler"
+  },
+  "confirmYes": {
+    "message": "Oui"
+  },
   "cannotUnloadActive": {
     "message": "Impossible de décharger l'onglet actif"
   },

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -116,6 +116,24 @@
   "thresholdUpdated": {
     "message": "Ambang diperbarui"
   },
+  "resetDefaults": {
+    "message": "Atur ulang ke default"
+  },
+  "confirmResetDefaults": {
+    "message": "Atur ulang semua pengaturan ke default? Tindakan ini tidak dapat dibatalkan."
+  },
+  "settingsReset": {
+    "message": "Pengaturan telah diatur ulang ke default"
+  },
+  "confirmResetShort": {
+    "message": "Anda yakin?"
+  },
+  "cancel": {
+    "message": "Batal"
+  },
+  "confirmYes": {
+    "message": "Ya"
+  },
   "cannotUnloadActive": {
     "message": "Tidak dapat membongkar tab yang aktif"
   },

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -116,6 +116,24 @@
   "thresholdUpdated": {
     "message": "しきい値を更新しました"
   },
+  "resetDefaults": {
+    "message": "デフォルトに戻す"
+  },
+  "confirmResetDefaults": {
+    "message": "すべての設定をデフォルトに戻しますか？この操作は元に戻せません。"
+  },
+  "settingsReset": {
+    "message": "設定をデフォルトに戻しました"
+  },
+  "confirmResetShort": {
+    "message": "よろしいですか？"
+  },
+  "cancel": {
+    "message": "キャンセル"
+  },
+  "confirmYes": {
+    "message": "はい"
+  },
   "cannotUnloadActive": {
     "message": "アクティブなタブはアンロードできません"
   },

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -116,6 +116,24 @@
   "thresholdUpdated": {
     "message": "임계값이 업데이트되었습니다"
   },
+  "resetDefaults": {
+    "message": "기본값으로 재설정"
+  },
+  "confirmResetDefaults": {
+    "message": "모든 설정을 기본값으로 재설정하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+  },
+  "settingsReset": {
+    "message": "설정이 기본값으로 재설정되었습니다"
+  },
+  "confirmResetShort": {
+    "message": "정말 재설정하시겠습니까?"
+  },
+  "cancel": {
+    "message": "취소"
+  },
+  "confirmYes": {
+    "message": "예"
+  },
   "cannotUnloadActive": {
     "message": "활성 탭은 언로드할 수 없습니다"
   },

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -116,6 +116,24 @@
   "thresholdUpdated": {
     "message": "Limite atualizado"
   },
+  "resetDefaults": {
+    "message": "Restaurar padrões"
+  },
+  "confirmResetDefaults": {
+    "message": "Restaurar todas as configurações para os padrões? Isso não pode ser desfeito."
+  },
+  "settingsReset": {
+    "message": "Configurações restauradas para os padrões"
+  },
+  "confirmResetShort": {
+    "message": "Tem certeza?"
+  },
+  "cancel": {
+    "message": "Cancelar"
+  },
+  "confirmYes": {
+    "message": "Sim"
+  },
   "cannotUnloadActive": {
     "message": "Não é possível descarregar a aba ativa"
   },

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -116,6 +116,24 @@
   "thresholdUpdated": {
     "message": "Порог обновлён"
   },
+  "resetDefaults": {
+    "message": "Сбросить настройки"
+  },
+  "confirmResetDefaults": {
+    "message": "Сбросить все настройки по умолчанию? Это действие нельзя отменить."
+  },
+  "settingsReset": {
+    "message": "Настройки сброшены по умолчанию"
+  },
+  "confirmResetShort": {
+    "message": "Вы уверены?"
+  },
+  "cancel": {
+    "message": "Отмена"
+  },
+  "confirmYes": {
+    "message": "Да"
+  },
   "cannotUnloadActive": {
     "message": "Нельзя выгрузить активную вкладку"
   },

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -112,6 +112,24 @@
   "thresholdUpdated": {
     "message": "Đã cập nhật ngưỡng"
   },
+  "resetDefaults": {
+    "message": "Khôi phục mặc định"
+  },
+  "confirmResetDefaults": {
+    "message": "Khôi phục tất cả cài đặt về mặc định? Thao tác này không thể hoàn tác."
+  },
+  "settingsReset": {
+    "message": "Đã khôi phục cài đặt mặc định"
+  },
+  "confirmResetShort": {
+    "message": "Bạn chắc chắn?"
+  },
+  "cancel": {
+    "message": "Hủy"
+  },
+  "confirmYes": {
+    "message": "Có"
+  },
   "cannotUnloadActive": {
     "message": "Không thể dỡ tab đang hoạt động"
   },

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -116,6 +116,24 @@
   "thresholdUpdated": {
     "message": "阈值已更新"
   },
+  "resetDefaults": {
+    "message": "恢复默认设置"
+  },
+  "confirmResetDefaults": {
+    "message": "将所有设置恢复为默认值？此操作无法撤销。"
+  },
+  "settingsReset": {
+    "message": "设置已恢复为默认值"
+  },
+  "confirmResetShort": {
+    "message": "确定要重置吗？"
+  },
+  "cancel": {
+    "message": "取消"
+  },
+  "confirmYes": {
+    "message": "是"
+  },
   "cannotUnloadActive": {
     "message": "无法释放当前活动标签页"
   },

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -56,12 +56,12 @@ tabrest/
 
 | File                   | LOC  | Purpose                                                                               |
 | ---------------------- | ---- | ------------------------------------------------------------------------------------- |
-| `popup/popup.js`       | 1168 | Main popup logic, tab list, actions, site whitelist toggle, bug report modal           |
-| `popup/popup.html`     | 314  | Popup markup (reused for side panel)                                                  |
-| `popup/popup.css`      | 1432 | Popup styles                                                                          |
-| `options/options.js`   | 428  | Settings management, Privacy & Diagnostics section with error reporting toggle        |
-| `options/options.html` | 267  | Options page markup, new Privacy & Diagnostics section with toggle + custom DSN field |
-| `options/options.css`  | 401  | Options styles                                                                        |
+| `popup/popup.js`       | 1191 | Main popup logic, tab list, actions, site whitelist toggle, reset settings, bug report modal |
+| `popup/popup.html`     | 322  | Popup markup (reused for side panel)                                                        |
+| `popup/popup.css`      | 1463 | Popup styles                                                                                |
+| `options/options.js`   | 485  | Settings management, reset to defaults, Privacy & Diagnostics section                       |
+| `options/options.html` | 410  | Options page markup, Privacy & Diagnostics section with toggle + custom DSN field           |
+| `options/options.css`  | 1116 | Options styles                                                                              |
 
 ### Shared Utilities
 

--- a/docs/feature-test-checklist.md
+++ b/docs/feature-test-checklist.md
@@ -306,21 +306,31 @@ For each of: **whitelist**, **blacklist**, **sessions**:
 - [ ] Every string in popup, options, onboarding, changelog, toast, notification, error message renders in Vietnamese (no `__MSG_*__` placeholders, no fallback English unless intentional).
 - [ ] Numbers/dates use locale-appropriate formatting.
 
-## 37. Settings Sync
+## 37. Reset Settings to Defaults
+
+- [ ] Popup → Quick Settings → click "Reset to Defaults" → inline confirm shows "Are you sure?" with Yes/Cancel.
+- [ ] Click "Cancel" → returns to original button, no changes.
+- [ ] Click "Yes" → all settings reset to `SETTINGS_DEFAULTS`; timer and threshold selects update immediately; toast shown.
+- [ ] Options → footer → click "Reset to Defaults" → browser confirm dialog appears.
+- [ ] Confirm → all settings (checkboxes, selects, radios, whitelist, blacklist) revert to defaults; status toast shown.
+- [ ] After reset, verify whitelist contains only default entries (`youtube.com`, `meet.google.com`).
+- [ ] After reset, verify power mode reverts to "Normal".
+
+## 38. Settings Sync
 
 - [ ] Sign in to Chrome with a sync-enabled account.
 - [ ] Modify settings on Profile A; on Profile B (signed in same account) verify sync within ~1 min.
 - [ ] Sessions and whitelist propagate across devices (sessions stored in `chrome.storage.sync`).
 - [ ] Tab activity stays per-device (`chrome.storage.local`).
 
-## 38. Service Worker Resilience
+## 39. Service Worker Resilience
 
 - [ ] In DevTools → Application → Service Workers → click "Stop" to terminate the worker.
 - [ ] Wait > 30s. Open a tab, then idle.
 - [ ] Worker auto-wakes via `chrome.alarms`; auto-unload still fires.
 - [ ] Long sessions (≥ 4 h) do not leak memory (`chrome://serviceworker-internals` shows stable heap).
 
-## 39. Cross-Browser Smoke (Chromium variants)
+## 40. Cross-Browser Smoke (Chromium variants)
 
 Spot-check on:
 
@@ -331,7 +341,7 @@ Spot-check on:
 
 Verify popup loads, manual unload works, side panel renders (where supported), shortcuts respond.
 
-## 40. Uninstall / Cleanup
+## 41. Uninstall / Cleanup
 
 - [ ] Remove extension → all alarms cleared.
 - [ ] Storage entries cleaned up by Chrome (verify via fresh reinstall: stats reset, no leftover snooze/sessions).

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -54,6 +54,7 @@
 - [x] Changelog page for updates
 - [x] Dark/light theme support
 - [x] Internationalization (EN, VI)
+- [x] Reset settings to defaults (popup + options page)
 
 #### Infrastructure
 

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -873,6 +873,15 @@ kbd {
   outline: none;
 }
 
+.footer-link--danger {
+  color: var(--danger);
+}
+
+.footer-link--danger:hover,
+.footer-link--danger:focus-visible {
+  color: var(--danger);
+}
+
 /* ---------- Scrollbar polish ---------- */
 ::-webkit-scrollbar {
   width: 10px;

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -398,6 +398,8 @@
       </span>
       <span class="footer-sep" aria-hidden="true">·</span>
       <button id="rerun-onboarding" type="button" class="footer-link" data-i18n="optionsRerunOnboarding">Run setup again</button>
+      <span class="footer-sep" aria-hidden="true">·</span>
+      <button id="reset-settings" type="button" class="footer-link footer-link--danger" data-i18n="resetDefaults">Reset to Defaults</button>
     </footer>
 
     <div id="status" class="status"></div>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -61,6 +61,7 @@ const elements = {
   status: document.getElementById("status"),
   shortcutsLink: document.getElementById("shortcuts-link"),
   rerunOnboarding: document.getElementById("rerun-onboarding"),
+  resetSettings: document.getElementById("reset-settings"),
   enableErrorReporting: document.getElementById("enable-error-reporting"),
   customSentryDsn: document.getElementById("custom-sentry-dsn"),
   dsnValidationMsg: document.getElementById("dsn-validation-msg"),
@@ -375,6 +376,19 @@ function setupEventListeners() {
   // Re-run onboarding wizard
   elements.rerunOnboarding?.addEventListener("click", () => {
     chrome.tabs.create({ url: chrome.runtime.getURL("src/pages/onboarding.html") });
+  });
+
+  // Reset all settings to defaults
+  elements.resetSettings?.addEventListener("click", async () => {
+    if (!confirm(t("confirmResetDefaults") || "Reset all settings to defaults? This cannot be undone.")) return;
+    currentSettings = {
+      ...SETTINGS_DEFAULTS,
+      whitelist: [...SETTINGS_DEFAULTS.whitelist],
+      blacklist: [...SETTINGS_DEFAULTS.blacklist],
+    };
+    await saveSettings(currentSettings);
+    await loadSettings();
+    showStatus(t("settingsReset") || "Settings reset to defaults");
   });
 }
 

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -380,7 +380,12 @@ function setupEventListeners() {
 
   // Reset all settings to defaults
   elements.resetSettings?.addEventListener("click", async () => {
-    if (!confirm(t("confirmResetDefaults") || "Reset all settings to defaults? This cannot be undone.")) return;
+    if (
+      !confirm(
+        t("confirmResetDefaults") || "Reset all settings to defaults? This cannot be undone.",
+      )
+    )
+      return;
     currentSettings = {
       ...SETTINGS_DEFAULTS,
       whitelist: [...SETTINGS_DEFAULTS.whitelist],

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -244,6 +244,37 @@ h1 {
   outline-offset: 1px;
 }
 
+.setting-row-reset {
+  justify-content: flex-end;
+  margin-top: 4px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+
+.btn-reset {
+  color: var(--danger);
+  border-color: var(--danger);
+  background: transparent;
+}
+
+.btn-reset:hover {
+  background: var(--danger);
+  color: #fff;
+  border-color: var(--danger);
+}
+
+.reset-confirm-group {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.reset-confirm-text {
+  font-size: 12px;
+  color: var(--danger);
+  font-weight: 500;
+}
+
 footer {
   text-align: center;
   font-size: 12px;

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -181,6 +181,14 @@
               <option value="95">95%</option>
             </select>
           </div>
+          <div class="setting-row setting-row-reset">
+            <span class="reset-confirm-group" id="reset-confirm-group" style="display:none;">
+              <span class="reset-confirm-text" data-i18n="confirmResetShort">Are you sure?</span>
+              <button class="btn btn-sm btn-reset" id="reset-confirm" data-i18n="confirmYes">Yes</button>
+              <button class="btn btn-sm" id="reset-cancel" data-i18n="cancel">Cancel</button>
+            </span>
+            <button class="btn btn-sm btn-reset" id="reset-settings" data-i18n="resetDefaults">Reset to Defaults</button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -1,4 +1,4 @@
-import { REPORT_REASONS, REPORTER_COMMANDS } from "../shared/constants.js";
+import { REPORT_REASONS, REPORTER_COMMANDS, SETTINGS_DEFAULTS } from "../shared/constants.js";
 import { sanitizeString } from "../shared/error-reporter.js";
 import { localizeHtml, t } from "../shared/i18n.js";
 import { icon, injectIcons } from "../shared/icons.js";
@@ -27,6 +27,10 @@ const elements = {
   settingsBtn: document.getElementById("settings-btn"),
   settingsToggle: document.getElementById("settings-toggle"),
   settingsBody: document.getElementById("settings-body"),
+  resetSettings: document.getElementById("reset-settings"),
+  resetConfirmGroup: document.getElementById("reset-confirm-group"),
+  resetConfirm: document.getElementById("reset-confirm"),
+  resetCancel: document.getElementById("reset-cancel"),
   // More actions
   moreToggle: document.getElementById("more-toggle"),
   moreBody: document.getElementById("more-body"),
@@ -921,6 +925,25 @@ function setupEventListeners() {
     showToast(t("thresholdUpdated"));
   });
 
+  // Reset settings to defaults (inline confirm to avoid Chrome popup clipping)
+  elements.resetSettings.addEventListener("click", () => {
+    elements.resetSettings.style.display = "none";
+    elements.resetConfirmGroup.style.display = "";
+  });
+
+  elements.resetCancel.addEventListener("click", () => {
+    elements.resetConfirmGroup.style.display = "none";
+    elements.resetSettings.style.display = "";
+  });
+
+  elements.resetConfirm.addEventListener("click", async () => {
+    await saveSettings({ ...SETTINGS_DEFAULTS });
+    await loadSettings();
+    elements.resetConfirmGroup.style.display = "none";
+    elements.resetSettings.style.display = "";
+    showToast(t("settingsReset") || "Settings reset to defaults");
+  });
+
   // Session save button
   elements.btnSaveSession.addEventListener("click", async () => {
     const result = await sendCommand("save-session", {
@@ -1146,8 +1169,12 @@ function setupTabEventSync() {
 
   const scheduleRefresh = leadingDebounce(renderTabList);
   const scheduleWhitelistRefresh = leadingDebounce(renderSiteWhitelistBar);
-  chrome.tabs.onActivated.addListener(scheduleRefresh);
-  chrome.tabs.onActivated.addListener(scheduleWhitelistRefresh);
+  chrome.tabs.onActivated.addListener(() => {
+    scheduleRefresh();
+    scheduleWhitelistRefresh();
+    elements.resetConfirmGroup.style.display = "none";
+    elements.resetSettings.style.display = "";
+  });
   chrome.tabs.onUpdated.addListener((_id, changeInfo) => {
     if ("discarded" in changeInfo || "title" in changeInfo || "favIconUrl" in changeInfo) {
       scheduleRefresh();

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -938,7 +938,7 @@ function setupEventListeners() {
 
   elements.resetConfirm.addEventListener("click", async () => {
     await saveSettings({ ...SETTINGS_DEFAULTS });
-    await loadSettings();
+    await Promise.all([loadSettings(), renderTabList(), renderSiteWhitelistBar(), updateStats()]);
     elements.resetConfirmGroup.style.display = "none";
     elements.resetSettings.style.display = "";
     showToast(t("settingsReset") || "Settings reset to defaults");


### PR DESCRIPTION
## Summary
- Add "Reset to Defaults" button in popup with inline confirm UI (avoids Chrome popup window clipping native `confirm()` dialogs)
- Add "Reset to Defaults" link in options page footer with native confirm dialog
- Add i18n translations for all 11 locales (de, en, es, fr, id, ja, ko, pt_BR, ru, vi, zh_CN)
- Deep-copy array settings (whitelist/blacklist) on reset to prevent `SETTINGS_DEFAULTS` mutation
- Reset inline confirm group on tab switch in side panel mode to prevent stale UI state

## Test plan
- [x] Open popup, click "Reset to Defaults", verify inline confirm appears (not native dialog)
- [x] Click "Cancel" in confirm group, verify it reverts to the reset button
- [x] Click "Yes" in confirm group, verify settings reset and toast appears
- [x] Open options page, click "Reset to Defaults" in footer, verify native confirm dialog
- [x] Confirm reset in options, verify all settings revert to defaults
- [x] After reset, add a domain to whitelist, verify `SETTINGS_DEFAULTS.whitelist` is not mutated
- [x] In side panel mode, open confirm group then switch tabs, verify confirm group resets
- [x] Verify translations render correctly in at least 2 non-English locales