### PR TITLE
fix(popup): re-render tab list when auto-unload timer changes

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -915,6 +915,7 @@ function setupEventListeners() {
     const settings = await getSettings();
     settings.unloadDelayMinutes = Number.parseInt(e.target.value, 10);
     await saveSettings(settings);
+    await renderTabList();
     showToast(t("timerUpdated"));
   });
 


### PR DESCRIPTION
## Summary
- Re-render the tab list when the "Auto-unload after" timer value is changed so countdown badges reflect the updated timeout immediately
- Previously, badges showed stale values until manual refresh

## Test plan
- [x] Open popup, note countdown badges on tabs
- [x] Change "Auto-unload after" to a different value
- [x] Verify countdown badges update immediately without manual refresh