### PR TITLE
fix(startup): force-discard all tabs across every window on browser launch

### DIFF
--- a/docs/feature-test-checklist.md
+++ b/docs/feature-test-checklist.md
@@ -57,7 +57,8 @@ Legend: `[ ]` not tested · `[x]` pass · `[!]` fail · `[~]` skip / N/A.
 
 - [ ] Toggle `Auto-unload on startup` ON (Options).
 - [ ] Quit and relaunch Chrome with multiple tabs open from previous session.
-- [ ] All non-active, non-whitelisted tabs discard within seconds of startup.
+- [ ] ALL non-active tabs discard within seconds of startup (including pinned and whitelisted).
+- [ ] Tabs in all restored windows are discarded, not just the focused window.
 - [ ] Toggle OFF → tabs remain loaded after relaunch.
 
 ## 5. Min Inactive Tabs Threshold

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -278,7 +278,7 @@ service-worker.js
 
 | Event                    | Handler                                          | Action                   |
 | ------------------------ | ------------------------------------------------ | ------------------------ |
-| `runtime.onStartup`      | Initialize all trackers, sync tabs, setup alarms | Startup                  |
+| `runtime.onStartup`      | Initialize trackers, sync tabs, force-discard all non-active tabs (all windows) | Startup                  |
 | `runtime.onInstalled`    | Same as startup + show onboarding/changelog      | Install/Update           |
 | `tabs.onActivated`       | Update tab activity timestamp                    | Tab focus                |
 | `tabs.onUpdated`         | Update activity, refresh badge                   | Tab navigation           |

--- a/docs/vi/feature-test-checklist.md
+++ b/docs/vi/feature-test-checklist.md
@@ -57,7 +57,8 @@ Ký hiệu: `[ ]` chưa test · `[x]` đạt · `[!]` lỗi · `[~]` bỏ qua / 
 
 - [ ] Bật `Auto-unload on startup` (Options).
 - [ ] Thoát Chrome rồi mở lại với nhiều tab từ phiên trước.
-- [ ] Mọi tab không active và không trong whitelist bị discard ngay sau khởi động.
+- [ ] TẤT CẢ tab không active bị discard ngay sau khởi động (bao gồm tab pin và whitelist).
+- [ ] Tab ở mọi cửa sổ được khôi phục đều bị discard, không chỉ cửa sổ đang focus.
 - [ ] Tắt → tab không discard sau khi mở lại.
 
 ## 5. Ngưỡng số tab inactive tối thiểu

--- a/src/background/unload-manager.js
+++ b/src/background/unload-manager.js
@@ -1,4 +1,4 @@
-import { FORM_CHECK_TIMEOUT_MS } from "../shared/constants.js";
+import { FORM_CHECK_TIMEOUT_MS, STARTUP_DISCARD_DELAY_MS } from "../shared/constants.js";
 import { getSettings } from "../shared/storage.js";
 import { unwrapHostname } from "../shared/utils.js";
 import { ensureFormCheckerInjected } from "./form-injector.js";
@@ -191,12 +191,20 @@ export async function discardOtherTabs() {
   return count;
 }
 
-// Discard all other tabs on browser startup (if enabled)
+// Force-discard all tabs across every window on browser startup.
 export async function discardAllTabsOnStartup() {
   const settings = await getSettings();
   if (!settings.autoUnloadOnStartup) return 0;
 
-  return await discardOtherTabs();
+  await new Promise((resolve) => setTimeout(resolve, STARTUP_DISCARD_DELAY_MS));
+
+  const tabs = await chrome.tabs.query({});
+  let count = 0;
+  for (const tab of tabs) {
+    if (!tab.active && !tab.discarded && (await discardTab(tab.id, { settings, force: true })))
+      count++;
+  }
+  return count;
 }
 
 // Discard all tabs in a specific tab group

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -112,6 +112,9 @@ export const SNOOZE_KEY = "tabrest_snooze";
 // Timeout for form data check (content script message)
 export const FORM_CHECK_TIMEOUT_MS = 300;
 
+// Grace period for Chrome to finish restoring session tabs before startup discard
+export const STARTUP_DISCARD_DELAY_MS = 2000;
+
 // Per-tab memory staleness threshold (2 minutes)
 export const MEMORY_STALE_THRESHOLD_MS = 120000;
 

--- a/tests/background/unload-manager.test.js
+++ b/tests/background/unload-manager.test.js
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { STARTUP_DISCARD_DELAY_MS } from "../../src/shared/constants.js";
 
 vi.mock("../../src/shared/storage.js", () => ({
   getSettings: vi.fn(),
@@ -299,19 +300,66 @@ describe("unload-manager", () => {
   });
 
   describe("discardAllTabsOnStartup", () => {
+    afterEach(() => vi.useRealTimers());
+
     it("returns 0 when autoUnloadOnStartup is disabled", async () => {
       getSettings.mockResolvedValue({ ...baseSettings, autoUnloadOnStartup: false });
       expect(await discardAllTabsOnStartup()).toBe(0);
     });
 
-    it("delegates to discardOtherTabs when enabled", async () => {
+    it("discards non-active tabs across all windows after delay", async () => {
+      vi.useFakeTimers();
       setupWindowTabs([
         { id: 1, url: "https://a.com", active: false, discarded: false },
         { id: 2, url: "https://b.com", active: true, discarded: false },
+        { id: 3, url: "https://c.com", active: false, discarded: false },
       ]);
 
-      const result = await discardAllTabsOnStartup();
+      const promise = discardAllTabsOnStartup();
+      await vi.advanceTimersByTimeAsync(STARTUP_DISCARD_DELAY_MS);
+      const result = await promise;
+
+      expect(result).toBe(2);
+      expect(chrome.tabs.discard).toHaveBeenCalledWith(1);
+      expect(chrome.tabs.discard).toHaveBeenCalledWith(3);
+      expect(chrome.tabs.discard).not.toHaveBeenCalledWith(2);
+    });
+
+    it("force-discards protected tabs (pinned, whitelisted)", async () => {
+      vi.useFakeTimers();
+      setupWindowTabs(
+        [
+          { id: 1, url: "https://a.com", active: false, discarded: false, pinned: true },
+          { id: 2, url: "https://b.com", active: true, discarded: false },
+          { id: 3, url: "https://safe.com/page", active: false, discarded: false },
+        ],
+        { settings: { ...baseSettings, unloadPinnedTabs: false, whitelist: ["safe.com"] } },
+      );
+
+      const promise = discardAllTabsOnStartup();
+      await vi.advanceTimersByTimeAsync(STARTUP_DISCARD_DELAY_MS);
+      const result = await promise;
+
+      expect(result).toBe(2);
+      expect(chrome.tabs.discard).toHaveBeenCalledWith(1);
+      expect(chrome.tabs.discard).toHaveBeenCalledWith(3);
+    });
+
+    it("skips already-discarded tabs", async () => {
+      vi.useFakeTimers();
+      setupWindowTabs([
+        { id: 1, url: "https://a.com", active: false, discarded: true },
+        { id: 2, url: "https://b.com", active: true, discarded: false },
+        { id: 3, url: "https://c.com", active: false, discarded: false },
+      ]);
+
+      const promise = discardAllTabsOnStartup();
+      await vi.advanceTimersByTimeAsync(STARTUP_DISCARD_DELAY_MS);
+      const result = await promise;
+
       expect(result).toBe(1);
+      expect(chrome.tabs.discard).toHaveBeenCalledWith(3);
+      expect(chrome.tabs.discard).not.toHaveBeenCalledWith(1);
     });
   });
 

--- a/website/src/content/docs/en/features.mdx
+++ b/website/src/content/docs/en/features.mdx
@@ -44,8 +44,8 @@ When triggered, TabRest unloads the least recently used (LRU) tabs until memory 
 Free memory immediately when Chrome starts:
 
 - **Default**: Enabled
-- **Behavior**: Unloads all tabs except the active one on browser launch
-- **Useful for**: Restoring many tabs from a previous session
+- **Behavior**: Force-unloads all non-active tabs across every window on browser launch, bypassing all protections (pinned, whitelist, audio, form)
+- **Useful for**: Restoring many tabs from a previous session without wasting memory
 
 ### Tab Count Threshold
 

--- a/website/src/content/docs/vi/features.mdx
+++ b/website/src/content/docs/vi/features.mdx
@@ -42,8 +42,8 @@ Khi kích hoạt, TabRest giải phóng các tab ít sử dụng nhất (LRU) ch
 Giải phóng bộ nhớ ngay khi Chrome khởi động:
 
 - **Mặc định**: Bật
-- **Hành vi**: Giải phóng tất cả tab trừ tab đang hoạt động khi trình duyệt khởi động
-- **Hữu ích cho**: Khôi phục nhiều tab từ phiên trước
+- **Hành vi**: Giải phóng tất cả tab không active ở mọi cửa sổ, bỏ qua mọi bảo vệ (tab pin, whitelist, audio, form)
+- **Hữu ích cho**: Khôi phục nhiều tab từ phiên trước mà không lãng phí bộ nhớ
 
 ### Ngưỡng số tab
 


### PR DESCRIPTION
## Summary
- Fixed startup unload not working due to timing (onStartup fires before Chrome restores tabs) and scope (only swept currentWindow)
- Added 2s delay (`STARTUP_DISCARD_DELAY_MS`) for Chrome to finish restoring session tabs
- Changed to query all tabs across all windows instead of just the focused window
- Startup sweep now force-discards all non-active tabs, bypassing all protections (pinned, whitelist, audio, form) since nothing needs protection on a fresh launch
- Pre-filters already-discarded tabs to avoid unnecessary API calls

## Test plan
- [x] 625 tests pass (35 in unload-manager, including 4 new startup tests)
- [x] Enable "Unload tabs on browser startup", quit Chrome with multiple tabs/windows open, relaunch - verify all non-active tabs are discarded
- [x] Verify pinned tabs and whitelisted tabs are also discarded on startup
- [x] Verify tabs across multiple restored windows are discarded
- [x] Disable "Unload tabs on browser startup", relaunch - verify tabs remain loaded