### PR TITLE
perf(startup): parallelize init and batch tab discarding

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -106,19 +106,22 @@ chrome.action.onClicked.addListener(async (_tab) => {
   updateBadge();
 });
 
+async function initCore() {
+  const [, , , , allTabs] = await Promise.all([
+    initErrorReporter(),
+    initTabTracker(),
+    initMemoryMonitor(),
+    initStats(),
+    chrome.tabs.query({}),
+  ]);
+  await Promise.all([syncAllTabs(allTabs), configureToolbarAction(), setupSnoozeCleanupAlarm()]);
+  return allTabs;
+}
+
 // Browser startup - initialize trackers and auto-unload
 chrome.runtime.onStartup.addListener(async () => {
-  await initErrorReporter();
-  await initTabTracker();
-  await initMemoryMonitor();
-  await initStats();
-  await syncAllTabs();
-  await cleanupStaleActivity();
-  await configureToolbarAction();
-  await setupSnoozeCleanupAlarm();
-  // Catch the case where the user revoked host permission via chrome://extensions
-  // between sessions; silently flip dependent toggles off (no banner - not an upgrade).
-  await syncHostPermissionState(false);
+  const allTabs = await initCore();
+  await Promise.all([cleanupStaleActivity(allTabs), syncHostPermissionState(false)]);
   await discardAllTabsOnStartup();
   updateBadge();
 });
@@ -126,7 +129,7 @@ chrome.runtime.onStartup.addListener(async () => {
 // Extension installed/updated
 chrome.runtime.onInstalled.addListener(async (details) => {
   // CWS/AMO compliance: no remote telemetry without explicit consent. Reset
-  // enableErrorReporting once per profile during the v0.0.5 → v0.1.0 rollout
+  // enableErrorReporting once per profile during the v0.0.5 -> v0.1.0 rollout
   // (when remote transport first ships). The migration flag prevents future
   // updates from silently clobbering a user's deliberate opt-in.
   if (details.reason === "install" || details.reason === "update") {
@@ -138,13 +141,7 @@ chrome.runtime.onInstalled.addListener(async (details) => {
     }
   }
 
-  await initErrorReporter();
-  await initTabTracker();
-  await initMemoryMonitor();
-  await initStats();
-  await syncAllTabs();
-  await configureToolbarAction();
-  await setupSnoozeCleanupAlarm();
+  await initCore();
   setupContextMenus();
   updateBadge();
 

--- a/src/background/tab-tracker.js
+++ b/src/background/tab-tracker.js
@@ -141,8 +141,8 @@ function debouncedSave() {
 }
 
 // Clean up activity entries for tabs that no longer exist
-export async function cleanupStaleActivity() {
-  const tabs = await chrome.tabs.query({});
+export async function cleanupStaleActivity(allTabs = null) {
+  const tabs = allTabs ?? (await chrome.tabs.query({}));
   const validTabIds = new Set(tabs.map((t) => t.id));
 
   let cleaned = 0;
@@ -160,8 +160,8 @@ export async function cleanupStaleActivity() {
 }
 
 // Initialize activity for all existing tabs
-export async function syncAllTabs() {
-  const tabs = await chrome.tabs.query({});
+export async function syncAllTabs(allTabs = null) {
+  const tabs = allTabs ?? (await chrome.tabs.query({}));
   const now = Date.now();
 
   for (const tab of tabs) {

--- a/src/background/unload-manager.js
+++ b/src/background/unload-manager.js
@@ -1,4 +1,8 @@
-import { FORM_CHECK_TIMEOUT_MS, STARTUP_DISCARD_DELAY_MS } from "../shared/constants.js";
+import {
+  FORM_CHECK_TIMEOUT_MS,
+  STARTUP_DISCARD_BATCH_SIZE,
+  STARTUP_DISCARD_DELAY_MS,
+} from "../shared/constants.js";
 import { getSettings } from "../shared/storage.js";
 import { queryCurrentWindowTabs, unwrapHostname } from "../shared/utils.js";
 import { ensureFormCheckerInjected } from "./form-injector.js";
@@ -198,10 +202,15 @@ export async function discardAllTabsOnStartup() {
   await new Promise((resolve) => setTimeout(resolve, STARTUP_DISCARD_DELAY_MS));
 
   const tabs = await chrome.tabs.query({});
+  const eligible = tabs.filter((t) => !t.active && !t.discarded);
+
   let count = 0;
-  for (const tab of tabs) {
-    if (!tab.active && !tab.discarded && (await discardTab(tab.id, { settings, force: true })))
-      count++;
+  for (let i = 0; i < eligible.length; i += STARTUP_DISCARD_BATCH_SIZE) {
+    const batch = eligible.slice(i, i + STARTUP_DISCARD_BATCH_SIZE);
+    const results = await Promise.all(
+      batch.map((tab) => discardTab(tab.id, { settings, force: true })),
+    );
+    count += results.filter(Boolean).length;
   }
   return count;
 }

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -113,7 +113,10 @@ export const SNOOZE_KEY = "tabrest_snooze";
 export const FORM_CHECK_TIMEOUT_MS = 300;
 
 // Grace period for Chrome to finish restoring session tabs before startup discard
-export const STARTUP_DISCARD_DELAY_MS = 2000;
+export const STARTUP_DISCARD_DELAY_MS = 500;
+
+// Max tabs to discard concurrently during startup batch
+export const STARTUP_DISCARD_BATCH_SIZE = 5;
 
 // Per-tab memory staleness threshold (2 minutes)
 export const MEMORY_STALE_THRESHOLD_MS = 120000;


### PR DESCRIPTION
## Summary
- Extract shared `initCore()` to run `initErrorReporter`, `initTabTracker`, `initMemoryMonitor`, `initStats`, and `chrome.tabs.query({})` in parallel via `Promise.all`, eliminating 3-4 redundant tab queries
- Batch tab discards in groups of 5 concurrently instead of sequential one-by-one processing
- Reduce `STARTUP_DISCARD_DELAY_MS` from 2000ms to 500ms - init phase provides implicit delay

## Test plan
- [x] Load extension in Chrome with 30+ tabs, restart browser, verify tabs are discarded correctly
- [x] Verify no lag increase compared to before (should be noticeably faster)
- [x] Verify popup opens and displays tab list correctly after startup
- [x] Verify extension install/update flow still works (context menus, onboarding page)
- [x] Verify whitelist/pinned/audio-protected tabs are not discarded on startup