### PR TITLE
fix(startup): add two-pass discard to catch late-restored tabs

### DIFF
--- a/src/background/unload-manager.js
+++ b/src/background/unload-manager.js
@@ -2,9 +2,10 @@ import {
   FORM_CHECK_TIMEOUT_MS,
   STARTUP_DISCARD_BATCH_SIZE,
   STARTUP_DISCARD_DELAY_MS,
+  STARTUP_FOLLOWUP_DELAY_MS,
 } from "../shared/constants.js";
 import { getSettings } from "../shared/storage.js";
-import { queryCurrentWindowTabs, unwrapHostname } from "../shared/utils.js";
+import { delay, queryCurrentWindowTabs, unwrapHostname } from "../shared/utils.js";
 import { ensureFormCheckerInjected } from "./form-injector.js";
 import { recordUnload } from "./stats-collector.js";
 
@@ -80,7 +81,7 @@ export async function discardTab(tabId, options = {}) {
         chrome.i18n.getMessage("suspendWarningMessage") ||
         "TabRest will suspend this tab to free memory…";
       await injectSuspendWarning(tabId, settings.suspendWarningDelayMs, message);
-      await new Promise((r) => setTimeout(r, settings.suspendWarningDelayMs));
+      await delay(settings.suspendWarningDelayMs);
 
       const refreshed = await chrome.tabs.get(tabId).catch(() => null);
       if (!refreshed || refreshed.active || refreshed.discarded) return false;
@@ -194,13 +195,7 @@ export async function discardOtherTabs() {
   return count;
 }
 
-// Force-discard all tabs across every window on browser startup.
-export async function discardAllTabsOnStartup() {
-  const settings = await getSettings();
-  if (!settings.autoUnloadOnStartup) return 0;
-
-  await new Promise((resolve) => setTimeout(resolve, STARTUP_DISCARD_DELAY_MS));
-
+async function batchDiscardEligible(settings) {
   const tabs = await chrome.tabs.query({});
   const eligible = tabs.filter((t) => !t.active && !t.discarded);
 
@@ -213,6 +208,20 @@ export async function discardAllTabsOnStartup() {
     count += results.filter(Boolean).length;
   }
   return count;
+}
+
+// Two passes: Chrome restores session tabs progressively over several seconds.
+export async function discardAllTabsOnStartup() {
+  const settings = await getSettings();
+  if (!settings.autoUnloadOnStartup) return 0;
+
+  await delay(STARTUP_DISCARD_DELAY_MS);
+  let totalCount = await batchDiscardEligible(settings);
+
+  await delay(STARTUP_FOLLOWUP_DELAY_MS);
+  totalCount += await batchDiscardEligible(settings);
+
+  return totalCount;
 }
 
 // Discard all tabs in a specific tab group

--- a/src/pages/onboarding/wizard.js
+++ b/src/pages/onboarding/wizard.js
@@ -1,5 +1,6 @@
 import { t } from "../../shared/i18n.js";
 import { getSettings } from "../../shared/storage.js";
+import { delay } from "../../shared/utils.js";
 import { decideAction } from "./decide-action.js";
 import { createState } from "./state.js";
 import { STEPS } from "./steps.js";
@@ -80,7 +81,7 @@ export function mountWizard(rootEl, deps = {}) {
     }
     const leavingClass = direction === "forward" ? "is-leaving-forward" : "is-leaving-back";
     stage.classList.add(leavingClass);
-    await new Promise((r) => setTimeout(r, TRANSITION_MS + TRANSITION_BUFFER_MS));
+    await delay(TRANSITION_MS + TRANSITION_BUFFER_MS);
     stage.classList.remove(leavingClass);
     applyVisibility();
     await renderStepBody();

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -113,7 +113,10 @@ export const SNOOZE_KEY = "tabrest_snooze";
 export const FORM_CHECK_TIMEOUT_MS = 300;
 
 // Grace period for Chrome to finish restoring session tabs before startup discard
-export const STARTUP_DISCARD_DELAY_MS = 500;
+export const STARTUP_DISCARD_DELAY_MS = 2000;
+
+// Follow-up delay after first pass to catch tabs Chrome restores late
+export const STARTUP_FOLLOWUP_DELAY_MS = 5000;
 
 // Max tabs to discard concurrently during startup batch
 export const STARTUP_DISCARD_BATCH_SIZE = 5;

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -134,6 +134,8 @@ export function formatBytes(bytes) {
   return `${Number.parseFloat((bytes / k ** i).toFixed(1))} ${sizes[i]}`;
 }
 
+export const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
 // Show notification for auto-unloaded tab
 export function notifyAutoUnload(tabTitle, reason, detail) {
   const title = reason === "timer" ? "💤 Tab unloaded (Timer)" : "💤 Tab unloaded (RAM)";

--- a/tests/background/unload-manager.test.js
+++ b/tests/background/unload-manager.test.js
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { STARTUP_DISCARD_DELAY_MS } from "../../src/shared/constants.js";
+import {
+  STARTUP_DISCARD_DELAY_MS,
+  STARTUP_FOLLOWUP_DELAY_MS,
+} from "../../src/shared/constants.js";
 
 vi.mock("../../src/shared/storage.js", () => ({
   getSettings: vi.fn(),
@@ -65,7 +68,11 @@ function setupWindowTabs(tabs, { settings = baseSettings } = {}) {
     }
     return Promise.resolve(tabs.find((t) => t.id === id) || null);
   });
-  chrome.tabs.discard.mockResolvedValue();
+  chrome.tabs.discard.mockImplementation((id) => {
+    const t = tabs.find((tab) => tab.id === id);
+    if (t) t.discarded = true;
+    return Promise.resolve();
+  });
   getSettings.mockResolvedValue(settings);
 }
 
@@ -316,7 +323,7 @@ describe("unload-manager", () => {
       ]);
 
       const promise = discardAllTabsOnStartup();
-      await vi.advanceTimersByTimeAsync(STARTUP_DISCARD_DELAY_MS);
+      await vi.advanceTimersByTimeAsync(STARTUP_DISCARD_DELAY_MS + STARTUP_FOLLOWUP_DELAY_MS);
       const result = await promise;
 
       expect(result).toBe(2);
@@ -337,7 +344,7 @@ describe("unload-manager", () => {
       );
 
       const promise = discardAllTabsOnStartup();
-      await vi.advanceTimersByTimeAsync(STARTUP_DISCARD_DELAY_MS);
+      await vi.advanceTimersByTimeAsync(STARTUP_DISCARD_DELAY_MS + STARTUP_FOLLOWUP_DELAY_MS);
       const result = await promise;
 
       expect(result).toBe(2);
@@ -354,7 +361,7 @@ describe("unload-manager", () => {
       ]);
 
       const promise = discardAllTabsOnStartup();
-      await vi.advanceTimersByTimeAsync(STARTUP_DISCARD_DELAY_MS);
+      await vi.advanceTimersByTimeAsync(STARTUP_DISCARD_DELAY_MS + STARTUP_FOLLOWUP_DELAY_MS);
       const result = await promise;
 
       expect(result).toBe(1);


### PR DESCRIPTION
## Summary
- Chrome restores session tabs progressively over several seconds; the previous single 500ms-delay scan missed tabs loaded after that window
- Added a second discard pass at 5s after the first (2s) to catch late-restored tabs
- Extracted shared `delay(ms)` utility to `src/shared/utils.js`, replacing 3 inline `new Promise(setTimeout)` patterns

## Changes
- `src/shared/constants.js`: `STARTUP_DISCARD_DELAY_MS` 500 -> 2000ms, added `STARTUP_FOLLOWUP_DELAY_MS` (5000ms)
- `src/background/unload-manager.js`: extracted `batchDiscardEligible()` helper, two-pass startup discard
- `src/shared/utils.js`: added `delay(ms)` utility
- `src/pages/onboarding/wizard.js`: use shared `delay()` instead of inline pattern

## Test plan
- [ ] Enable "Auto-unload on startup" in TabRest options
- [ ] Open 10+ tabs, close Chrome, reopen
- [ ] Verify all inactive tabs are discarded within ~7s of startup
- [ ] Check service worker console for errors
- [ ] Verify onboarding wizard transitions still work