### PR TITLE
fix(background): prevent "No current window" from chrome.tabs.create

### DIFF
--- a/src/background/service-worker.js
+++ b/src/background/service-worker.js
@@ -13,6 +13,7 @@ import {
 import { HOST_PERM_DEPENDENT_FLAGS, hasHostPermission } from "../shared/permissions.js";
 import { getSettings, saveSettings } from "../shared/storage.js";
 import {
+  createTabSafe,
   isMinorOrMajorBump,
   isValidDomainOrIp,
   queryCurrentWindowTabs,
@@ -151,13 +152,13 @@ chrome.runtime.onInstalled.addListener(async (details) => {
   if (details.reason === "install") {
     // First install - show onboarding, store version to track future bumps
     await chrome.storage.local.set({ tabrest_lastVersion: currentVersion });
-    chrome.tabs.create({ url: "src/pages/onboarding.html" });
+    await createTabSafe({ url: "src/pages/onboarding.html" });
   } else if (details.reason === "update") {
     const stored = await chrome.storage.local.get("tabrest_lastVersion");
     const prevVersion = details.previousVersion || stored.tabrest_lastVersion;
 
     if (prevVersion && isMinorOrMajorBump(prevVersion, currentVersion)) {
-      chrome.tabs.create({ url: "https://tabrest.ohnice.app/changelog" });
+      await createTabSafe({ url: "https://tabrest.ohnice.app/changelog" });
     }
     await chrome.storage.local.set({ tabrest_lastVersion: currentVersion });
   }
@@ -435,7 +436,8 @@ async function openLinkSuspended(url) {
   }
 
   // Create tab in background (not active)
-  const tab = await chrome.tabs.create({ url, active: false });
+  const tab = await createTabSafe({ url, active: false });
+  if (!tab?.id) return false;
 
   let timeoutId = null;
 

--- a/src/background/session-manager.js
+++ b/src/background/session-manager.js
@@ -1,7 +1,7 @@
 // Session management module
 // Handles saving, restoring, and managing tab sessions
 
-import { isSafeHttpUrl, queryCurrentWindowTabs } from "../shared/utils.js";
+import { createTabSafe, isSafeHttpUrl, queryCurrentWindowTabs } from "../shared/utils.js";
 
 const MAX_SESSIONS = 20;
 const SESSIONS_KEY = "tabrest_sessions";
@@ -117,19 +117,19 @@ export async function restoreSession(id, mode = "open") {
 
     // Create first tab
     const firstTab = validTabs[0];
-    const newTab = await chrome.tabs.create({
+    const newTab = await createTabSafe({
       url: firstTab.url,
       pinned: firstTab.pinned,
       active: true,
     });
 
     // Close old tabs
-    const oldIds = currentTabs.map((t) => t.id).filter((tabId) => tabId !== newTab.id);
+    const oldIds = currentTabs.map((t) => t.id).filter((tabId) => tabId !== newTab?.id);
     if (oldIds.length) await chrome.tabs.remove(oldIds);
 
     // Create remaining tabs
     for (let i = 1; i < validTabs.length; i++) {
-      await chrome.tabs.create({
+      await createTabSafe({
         url: validTabs[i].url,
         pinned: validTabs[i].pinned,
         active: false,
@@ -138,7 +138,7 @@ export async function restoreSession(id, mode = "open") {
   } else {
     // Open mode - just add tabs
     for (const tab of validTabs) {
-      await chrome.tabs.create({
+      await createTabSafe({
         url: tab.url,
         pinned: tab.pinned,
         active: false,

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -134,6 +134,26 @@ export async function queryCurrentWindowTabs(extraQuery = {}) {
   }
 }
 
+// chrome.tabs.create() targets the "current window" when windowId is omitted,
+// throwing "No current window" if none is focused (all windows minimized, or the
+// service worker woke on an event with no focused window - e.g. onInstalled during
+// a background update). Resolve an explicit target so tab creation never rejects
+// on that condition. Non-window errors are re-thrown so genuine bugs still surface.
+export async function createTabSafe(createProps) {
+  try {
+    return await chrome.tabs.create(createProps);
+  } catch (error) {
+    if (!error?.message?.includes("No current window")) throw error;
+    // Fall back to the most recently focused normal window, else open a new one.
+    const win = await chrome.windows.getLastFocused({ windowTypes: ["normal"] }).catch(() => null);
+    if (win?.id != null) {
+      return await chrome.tabs.create({ ...createProps, windowId: win.id });
+    }
+    const created = await chrome.windows.create({ url: createProps.url });
+    return created?.tabs?.[0] ?? null;
+  }
+}
+
 // Format bytes to human readable string
 export function formatBytes(bytes) {
   if (!bytes || bytes === 0) return "0 B";

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -47,6 +47,10 @@ global.chrome = {
     onUpdated: { addListener: vi.fn() },
     onRemoved: { addListener: vi.fn() },
   },
+  windows: {
+    getLastFocused: vi.fn(() => Promise.resolve({ id: 1 })),
+    create: vi.fn(() => Promise.resolve({ id: 2, tabs: [{ id: 998 }] })),
+  },
   alarms: {
     create: vi.fn(),
     clear: vi.fn(() => Promise.resolve(true)),

--- a/tests/shared/utils-extra.test.js
+++ b/tests/shared/utils-extra.test.js
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  createTabSafe,
   getBrowserInfo,
   isSafeFaviconUrl,
   isSafeHttpUrl,
@@ -122,6 +123,51 @@ describe("isSafeFaviconUrl", () => {
     expect(isSafeFaviconUrl("chrome://extensions")).toBe(false);
     expect(isSafeFaviconUrl("")).toBe(false);
     expect(isSafeFaviconUrl(null)).toBe(false);
+  });
+});
+
+describe("createTabSafe", () => {
+  const NO_WINDOW = () => Promise.reject(new Error("No current window"));
+
+  it("creates the tab directly when a current window exists", async () => {
+    chrome.tabs.create.mockResolvedValueOnce({ id: 42 });
+    const tab = await createTabSafe({ url: "https://example.com" });
+    expect(tab).toEqual({ id: 42 });
+    expect(chrome.tabs.create).toHaveBeenCalledTimes(1);
+    expect(chrome.windows.getLastFocused).not.toHaveBeenCalled();
+  });
+
+  it("retries in the last focused window on 'No current window'", async () => {
+    // Without the fix this rejection escapes as an unhandled promise rejection
+    // (reported to Sentry as "No current window"). The helper must recover.
+    chrome.tabs.create.mockImplementationOnce(NO_WINDOW);
+    chrome.tabs.create.mockResolvedValueOnce({ id: 7, windowId: 1 });
+    chrome.windows.getLastFocused.mockResolvedValueOnce({ id: 1 });
+
+    const tab = await createTabSafe({ url: "https://example.com" });
+
+    expect(tab).toEqual({ id: 7, windowId: 1 });
+    expect(chrome.tabs.create).toHaveBeenLastCalledWith({
+      url: "https://example.com",
+      windowId: 1,
+    });
+  });
+
+  it("opens a new window when no window exists at all", async () => {
+    chrome.tabs.create.mockImplementationOnce(NO_WINDOW);
+    chrome.windows.getLastFocused.mockRejectedValueOnce(new Error("No current window"));
+    chrome.windows.create.mockResolvedValueOnce({ id: 5, tabs: [{ id: 99 }] });
+
+    const tab = await createTabSafe({ url: "https://example.com" });
+
+    expect(chrome.windows.create).toHaveBeenCalledWith({ url: "https://example.com" });
+    expect(tab).toEqual({ id: 99 });
+  });
+
+  it("re-throws non-window errors so real bugs still surface", async () => {
+    chrome.tabs.create.mockImplementationOnce(() => Promise.reject(new Error("Tab boom")));
+    await expect(createTabSafe({ url: "https://example.com" })).rejects.toThrow("Tab boom");
+    expect(chrome.windows.getLastFocused).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Problem

Sentry error **TABREST-B: "No current window"** (release `tabrest@0.7.0`, surface `unknown`, empty stack).

`chrome.tabs.create({...})` without an explicit `windowId` targets the *current window*, which throws `"No current window"` when none is focused - all windows minimized, or the service worker woke on an event with no focused window. The call sites live in async listeners without `.catch()`, so the rejection escaped as an **unhandled promise rejection** and was captured by the SW global handler in `error-reporter.js` (hence empty stack + surface `unknown`).

Correlates with the 0.7.0 spike: `onInstalled` (reason `update`) on a minor/major bump calls `chrome.tabs.create({ url: ".../changelog" })` with no `windowId`; when the update applied while no window was focused, it threw.

## Fix

Follows the existing `queryCurrentWindowTabs()` convention from #88:

- Add `createTabSafe()` in `src/shared/utils.js` - catches only `"No current window"`, resolves the last focused normal window and retries with an explicit `windowId`, and opens a new window if none exists. **Re-throws non-window errors** so genuine bugs still surface.
- Route all service-worker tab creation through it: onboarding + changelog tabs (`onInstalled`), `openLinkSuspended`, and `restoreSession` (3 calls).

Raw `chrome.tabs.create` in page contexts (options/popup/onboarding) left unchanged - they always run with a focused window; the condition is a service-worker-only hazard.

## Testing

- 4 new regression tests for `createTabSafe` (direct create, last-focused retry, new-window fallback, non-window re-throw).
- Lint clean · full suite **633/633 pass**.