### PR TITLE
fix(ci): approve esbuild build script for pnpm 11

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+onlyBuiltDependencies:
+  - esbuild


### PR DESCRIPTION
## Problem

Upgrading pnpm to v11 (#94) fails the `Lint & Validate` CI job:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.28.1
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```

pnpm 11 changes the default of `strictDepBuilds` from `false` to `true`, so a dependency with an ignored build script (`esbuild`) now fails `pnpm install` instead of only printing a warning. The website workspace already declares `onlyBuiltDependencies` in `website/pnpm-workspace.yaml`, but the repo root had no pnpm config.

## Fix

Add a root `pnpm-workspace.yaml` approving the `esbuild` build script:

```yaml
onlyBuiltDependencies:
  - esbuild
```

## Verification

```
pnpm install --frozen-lockfile --config.strictDepBuilds=true
```

Passes with no `ERR_PNPM_IGNORED_BUILDS`; lockfile unchanged. This unblocks #94 once Renovate rebases it.